### PR TITLE
Set up repository scaffolding with Hatch and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Hatch
+        run: python -m pip install --upgrade pip hatch
+
+      - name: Run linters
+        run: hatch run lint
+
+      - name: Run tests
+        run: hatch run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,79 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+*.pyc
+*.pyo
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Hatch
+.hatch/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDEs and editors
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+
+# Mac
+.DS_Store
+
+# Logs
+*.log
+
+# Others
+*.swp
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # 3dfs
+
+Cross-platform 3D file explorer and customization platform. This
+repository currently contains the scaffolding for the Python-based
+application, including build tooling, testing, linting, and coding
+standards documentation.
+
+## Getting Started
+
+1. Install the project dependencies using [Hatch](https://hatch.pypa.io/):
+
+   ```bash
+   pip install hatch
+   hatch env create
+   ```
+
+2. Run the automated checks:
+
+   ```bash
+   hatch run lint
+   hatch run test
+   ```
+
+3. Explore the project structure:
+
+   ```text
+   .
+   ├── docs/                  # Engineering documentation
+   │   └── CODING_STANDARDS.md
+   ├── src/
+   │   └── three_dfs/         # Application package (src layout)
+   ├── tests/                 # Pytest-based unit tests
+   ├── .github/workflows/     # Continuous integration pipelines
+   ├── pyproject.toml         # Build system and tooling configuration
+   └── README.md              # Project overview
+   ```
+
+Additional design documents, architectural notes, and implementation
+code will be layered onto this foundation in subsequent milestones.

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -1,0 +1,64 @@
+# Coding Standards
+
+This document outlines the baseline conventions for contributing to the
+3dfs codebase. The intent is to encourage a predictable, maintainable
+code style that can scale as the application grows.
+
+## Python Version
+
+- Target **Python 3.11** or newer.
+- Prefer using modern standard-library features (e.g. `pathlib`,
+  dataclasses, `typing.Self`) whenever they simplify the code.
+
+## Formatting & Linting
+
+- Run `hatch run lint` before opening a pull request. The command executes:
+  - [`ruff`](https://docs.astral.sh/ruff/) for static analysis and import
+    sorting.
+  - [`black`](https://black.readthedocs.io/) in check mode to ensure a
+    consistent code format.
+- The project uses an 88-character line length for both Ruff and Black.
+- Avoid `# noqa` or ignore comments unless there is a compelling,
+  well-documented reason.
+
+## Testing
+
+- Add unit tests for all new modules and behaviours. Existing tests may
+  be a guide for style and structure.
+- Execute `hatch run test` locally to run the `pytest` suite with code
+  coverage reporting.
+- Structure tests to be deterministic and platform agnostic. Avoid
+  relying on absolute paths or system-specific configurations.
+
+## Type Hints
+
+- Prefer comprehensive static typing using the standard `typing` module.
+  Future tooling may introduce optional strict type checking.
+- Use [PEP 563](https://peps.python.org/pep-0563/) style postponed
+  evaluation via `from __future__ import annotations` for new modules to
+  simplify annotation usage.
+
+## Project Structure
+
+- Place source files under `src/three_dfs/` using
+  [src-layout packaging](https://packaging.python.org/en/latest/discussions/src-layout/).
+- Keep modules focused on a single responsibility; break larger modules
+  into packages when appropriate.
+- Use descriptive module and package names. Avoid abbreviations unless
+  they are industry standard.
+
+## Documentation & Comments
+
+- Provide module docstrings summarizing purpose and usage.
+- Write clear inline comments only when the intent is not obvious from
+  the code itself.
+- Update the project documentation (`README.md`, design docs) when
+  behaviour or external interfaces change.
+
+## Commit Messages
+
+- Use imperative mood (e.g. "Add customizer preview skeleton").
+- Reference related issues or roadmap items when possible.
+
+Following these standards will help maintain a coherent and approachable
+codebase as 3dfs evolves.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["hatchling>=1.21.1"]
+build-backend = "hatchling.build"
+
+[project]
+name = "three-dfs"
+version = "0.1.0"
+description = "Foundational tooling for the 3dfs cross-platform 3D asset explorer."
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "3dfs Contributors" }]
+keywords = ["3d", "cad", "explorer", "desktop"]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Intended Audience :: Developers",
+  "License :: Other/Proprietary License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+]
+
+[tool.hatch.build.targets.sdist]
+include = ["src", "tests", "docs", "README.md"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/three_dfs"]
+
+[tool.hatch.envs.default]
+dependencies = [
+  "pytest>=7.4",
+  "pytest-cov>=4.1",
+  "ruff>=0.4.2",
+  "black>=24.3.0",
+]
+
+[tool.hatch.envs.default.scripts]
+lint = [
+  "ruff check src tests",
+  "black --check src tests",
+]
+test = "pytest --cov=three_dfs --cov-report=term-missing"
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+select = ["E", "F", "I", "B", "UP", "W"]
+
+[tool.pytest.ini_options]
+addopts = "-ra --strict-markers"
+testpaths = [
+  "tests",
+]

--- a/src/three_dfs/__init__.py
+++ b/src/three_dfs/__init__.py
@@ -1,0 +1,11 @@
+"""Top-level package for the 3dfs application.
+
+This package currently exposes foundational constants and helpers that
+will be expanded as the application evolves.
+"""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,12 @@
+"""Basic smoke tests for the 3dfs package."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_package_importable() -> None:
+    """Ensure that the top-level package can be imported."""
+
+    module = importlib.import_module("three_dfs")
+    assert module.__version__ == "0.1.0"


### PR DESCRIPTION
## Summary
- configure a Hatch-based `pyproject.toml` with testing and linting environments alongside an initial package skeleton
- document coding standards and update the README with setup instructions for contributors
- add a GitHub Actions workflow and repository `.gitignore` to run linting and unit tests automatically

## Testing
- hatch run lint
- hatch run test

------
https://chatgpt.com/codex/tasks/task_e_68cad86887a08325a49289068c838e22