### PR TITLE
Add GUI application entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,19 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Topic :: Scientific/Engineering :: Information Analysis",
 ]
+dependencies = [
+  "PySide6>=6.7",
+  "Pillow>=10.3",
+]
 
 [tool.hatch.build.targets.sdist]
 include = ["src", "tests", "docs", "README.md"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/three_dfs"]
+
+[project.scripts]
+three-dfs = "three_dfs.app:main"
 
 [tool.hatch.envs.default]
 dependencies = [

--- a/src/three_dfs/__main__.py
+++ b/src/three_dfs/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for ``python -m three_dfs``."""
+
+from __future__ import annotations
+
+from .app import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/three_dfs/app.py
+++ b/src/three_dfs/app.py
@@ -1,0 +1,41 @@
+"""Application bootstrap for the 3dfs desktop shell."""
+
+from __future__ import annotations
+
+import sys
+from typing import Final
+
+from PySide6.QtWidgets import QApplication, QMainWindow
+
+WINDOW_TITLE: Final[str] = "3dfs"
+
+
+class MainWindow(QMainWindow):
+    """Primary window for the 3dfs shell."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle(WINDOW_TITLE)
+
+
+def main() -> int:
+    """Launch the 3dfs Qt application."""
+
+    app = QApplication.instance()
+    owns_application = False
+
+    if app is None:
+        app = QApplication(sys.argv)
+        owns_application = True
+
+    window = MainWindow()
+    window.show()
+
+    if owns_application:
+        return app.exec()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add PySide6 and Pillow to the project dependencies and register a console script entry point
- implement a minimal Qt MainWindow and QApplication bootstrap in `three_dfs.app`
- enable running the shell with `python -m three_dfs` via a package `__main__` module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb061b93b083259990eec2ebb649a7