### PR TITLE
Add tag sidebar widget and persistence layer

### DIFF
--- a/src/three_dfs/app.py
+++ b/src/three_dfs/app.py
@@ -5,7 +5,21 @@ from __future__ import annotations
 import sys
 from typing import Final
 
-from PySide6.QtWidgets import QApplication, QMainWindow
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .data import TagStore
+from .ui import TagSidebar
 
 WINDOW_TITLE: Final[str] = "3dfs"
 
@@ -16,6 +30,113 @@ class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle(WINDOW_TITLE)
+
+        self._tag_store = TagStore()
+        self._tag_sidebar = TagSidebar(self._tag_store)
+        self._repository_list = QListWidget(self)
+        self._repository_list.setObjectName("repositoryList")
+        self._repository_list.setSelectionMode(QAbstractItemView.SingleSelection)
+
+        self._preview_label = QLabel("Select an item to preview", self)
+        self._preview_label.setObjectName("previewLabel")
+        self._preview_label.setAlignment(Qt.AlignCenter)
+
+        self._build_layout()
+        self._connect_signals()
+        self._populate_repository()
+
+    # ------------------------------------------------------------------
+    # Layout & wiring
+    # ------------------------------------------------------------------
+    def _build_layout(self) -> None:
+        central_widget = QWidget(self)
+        layout = QVBoxLayout(central_widget)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        splitter = QSplitter(Qt.Horizontal, central_widget)
+        splitter.addWidget(self._repository_list)
+        splitter.addWidget(self._preview_label)
+        splitter.addWidget(self._tag_sidebar)
+        splitter.setStretchFactor(0, 2)
+        splitter.setStretchFactor(1, 3)
+        splitter.setStretchFactor(2, 1)
+
+        layout.addWidget(splitter)
+        self.setCentralWidget(central_widget)
+
+    def _connect_signals(self) -> None:
+        self._repository_list.currentItemChanged.connect(self._handle_selection_change)
+        self._tag_sidebar.searchRequested.connect(self._handle_search_request)
+        self._tag_sidebar.tagsChanged.connect(self._handle_tags_changed)
+
+    def _populate_repository(self) -> None:
+        """Populate the mock repository view with placeholder entries."""
+
+        sample_items = [
+            ("docs/overview.md", "Project overview"),
+            ("assets/textures/terrain.png", "Terrain texture"),
+            ("assets/models/ship.fbx", "Spaceship model"),
+            ("scripts/build.py", "Build automation script"),
+            ("notes/ideas.txt", "Concept notes"),
+        ]
+
+        for item_id, label in sample_items:
+            widget_item = QListWidgetItem(label)
+            widget_item.setData(Qt.UserRole, item_id)
+            self._repository_list.addItem(widget_item)
+
+        if self._repository_list.count():
+            self._repository_list.setCurrentRow(0)
+
+    # ------------------------------------------------------------------
+    # Signal handlers
+    # ------------------------------------------------------------------
+    def _handle_selection_change(
+        self, current: QListWidgetItem | None, previous: QListWidgetItem | None
+    ) -> None:
+        del previous  # unused but part of the Qt signal signature
+
+        if current is None:
+            self._preview_label.setText("Select an item to preview")
+            self._tag_sidebar.set_active_item(None)
+            return
+
+        item_id = current.data(Qt.UserRole) or current.text()
+        item_id = str(item_id)
+        self._preview_label.setText(f"Preview for {current.text()}")
+        self._tag_sidebar.set_active_item(item_id)
+
+    def _handle_search_request(self, query: str) -> None:
+        normalized = query.strip()
+        self._apply_search_filter(normalized)
+
+        if normalized:
+            message = f"Filtering repository by tag: {normalized}"
+        else:
+            message = "Cleared tag search"
+
+        self.statusBar().showMessage(message, 2000)
+
+    def _handle_tags_changed(self, item_id: str, tags: list[str]) -> None:
+        self._apply_search_filter(self._tag_sidebar.search_text())
+        self.statusBar().showMessage(f"{len(tags)} tag(s) assigned to {item_id}", 2000)
+
+    def _apply_search_filter(self, normalized_query: str) -> None:
+        normalized = normalized_query.strip()
+
+        if not normalized:
+            for row in range(self._repository_list.count()):
+                item = self._repository_list.item(row)
+                item.setHidden(False)
+            return
+
+        matching_items = set(self._tag_store.search(normalized).keys())
+
+        for row in range(self._repository_list.count()):
+            item = self._repository_list.item(row)
+            item_id = str(item.data(Qt.UserRole) or item.text())
+            item.setHidden(item_id not in matching_items)
 
 
 def main() -> int:

--- a/src/three_dfs/data/__init__.py
+++ b/src/three_dfs/data/__init__.py
@@ -1,0 +1,7 @@
+"""Data access helpers for the 3dfs application."""
+
+from __future__ import annotations
+
+from .tags import TagStore
+
+__all__ = ["TagStore"]

--- a/src/three_dfs/data/tags.py
+++ b/src/three_dfs/data/tags.py
@@ -1,0 +1,241 @@
+"""Tag persistence helpers.
+
+This module provides a light-weight persistence layer for associating text
+labels ("tags") with arbitrary repository item identifiers.  The
+implementation is intentionally simple – a JSON file on disk – but exposes a
+clean API that higher level UI components can rely on.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+__all__ = ["TagStore"]
+
+DEFAULT_DATA_DIR = Path.home() / ".3dfs"
+DEFAULT_DATA_FILE = DEFAULT_DATA_DIR / "tags.json"
+
+
+class TagStore:
+    """Persist and query tag assignments for repository items.
+
+    Parameters
+    ----------
+    path:
+        Optional location for the backing JSON file.  When omitted a file in
+        the user's home directory (``~/.3dfs/tags.json``) is used.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path) if path is not None else DEFAULT_DATA_FILE
+        self._records: dict[str, list[str]] = {}
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Basic helpers
+    # ------------------------------------------------------------------
+    @property
+    def path(self) -> Path:
+        """Return the resolved location of the persistence file."""
+
+        return self._path
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def tags_for(self, item_id: str) -> list[str]:
+        """Return a copy of the tags assigned to *item_id*.
+
+        The returned list is always sorted alphabetically (case-insensitive)
+        and can be mutated by the caller without affecting the stored state.
+        """
+
+        item_key = self._normalize_item_id(item_id)
+        tags = self._records.get(item_key, [])
+        return list(tags)
+
+    def set_tags(self, item_id: str, tags: Iterable[str]) -> list[str]:
+        """Replace the tags for *item_id* with *tags*.
+
+        Returns the normalized, sorted tag list that was persisted.
+        """
+
+        item_key = self._normalize_item_id(item_id)
+        normalized = self._normalize_tag_iterable(tags)
+
+        if normalized:
+            self._records[item_key] = normalized
+        else:
+            self._records.pop(item_key, None)
+
+        self._save()
+        return list(normalized)
+
+    def add_tag(self, item_id: str, tag: str) -> str | None:
+        """Add *tag* to *item_id* and return the normalized value.
+
+        ``None`` is returned when the tag already exists for the item.
+        """
+
+        item_key = self._normalize_item_id(item_id)
+        normalized = self._normalize_tag(tag)
+        tags = self._records.setdefault(item_key, [])
+
+        if normalized in tags:
+            return None
+
+        tags.append(normalized)
+        tags.sort(key=str.casefold)
+        self._save()
+        return normalized
+
+    def remove_tag(self, item_id: str, tag: str) -> bool:
+        """Remove *tag* from *item_id* if present."""
+
+        item_key = self._normalize_item_id(item_id)
+        normalized = self._normalize_tag(tag)
+        tags = self._records.get(item_key)
+
+        if not tags or normalized not in tags:
+            return False
+
+        tags.remove(normalized)
+
+        if tags:
+            tags.sort(key=str.casefold)
+        else:
+            del self._records[item_key]
+
+        self._save()
+        return True
+
+    def rename_tag(self, item_id: str, old_tag: str, new_tag: str) -> str | None:
+        """Rename *old_tag* to *new_tag* for *item_id*.
+
+        The normalized new tag name is returned on success.  ``None`` is
+        returned when *old_tag* does not exist for the item or when *new_tag*
+        would collide with an existing entry.
+        """
+
+        item_key = self._normalize_item_id(item_id)
+        tags = self._records.get(item_key)
+
+        if not tags:
+            return None
+
+        old_normalized = self._normalize_tag(old_tag)
+        if old_normalized not in tags:
+            return None
+
+        new_normalized = self._normalize_tag(new_tag)
+
+        if new_normalized in tags and new_normalized != old_normalized:
+            return None
+
+        index = tags.index(old_normalized)
+        tags[index] = new_normalized
+        tags.sort(key=str.casefold)
+        self._save()
+        return new_normalized
+
+    def search(self, query: str) -> dict[str, list[str]]:
+        """Return all tags whose text contains *query* (case-insensitive)."""
+
+        needle = str(query or "").strip().casefold()
+
+        if not needle:
+            return {item_id: list(tags) for item_id, tags in self._records.items()}
+
+        results: dict[str, list[str]] = {}
+
+        for item_id, tags in self._records.items():
+            matches = [tag for tag in tags if needle in tag.casefold()]
+            if matches:
+                results[item_id] = matches
+
+        return results
+
+    def all_tags(self) -> list[str]:
+        """Return a sorted list of every tag stored for any item."""
+
+        universe = {tag for tags in self._records.values() for tag in tags}
+        return sorted(universe, key=str.casefold)
+
+    def iter_items(self) -> Iterator[tuple[str, list[str]]]:
+        """Yield ``(item_id, tags)`` pairs for every stored item."""
+
+        for item_id, tags in self._records.items():
+            yield item_id, list(tags)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _normalize_item_id(self, item_id: str) -> str:
+        value = str(item_id)
+        if not value:
+            raise ValueError("Item identifier cannot be empty.")
+        return value
+
+    def _normalize_tag(self, tag: str) -> str:
+        value = str(tag).strip()
+        if not value:
+            raise ValueError("Tags must contain visible characters.")
+        return value
+
+    def _normalize_tag_iterable(self, tags: Iterable[str]) -> list[str]:
+        unique: dict[str, None] = {}
+        for tag in tags:
+            normalized = self._normalize_tag(tag)
+            unique.setdefault(normalized, None)
+        return sorted(unique.keys(), key=str.casefold)
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            self._records = {}
+            return
+
+        try:
+            with self._path.open("r", encoding="utf8") as handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            self._records = {}
+            return
+
+        items = payload.get("items") if isinstance(payload, dict) else None
+        if not isinstance(items, dict):
+            self._records = {}
+            return
+
+        records: dict[str, list[str]] = {}
+
+        for item_id, tags in items.items():
+            if not isinstance(tags, list):
+                continue
+
+            key = str(item_id)
+            normalized_tags = [
+                str(tag).strip() for tag in tags if str(tag).strip()
+            ]
+
+            if normalized_tags:
+                records[key] = sorted(set(normalized_tags), key=str.casefold)
+
+        self._records = records
+
+    def _save(self) -> None:
+        if not self._records:
+            # Remove the file entirely when no tags remain to avoid leaving
+            # behind empty JSON files.
+            try:
+                self._path.unlink()
+            except FileNotFoundError:
+                pass
+            return
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"items": self._records}
+
+        with self._path.open("w", encoding="utf8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)

--- a/src/three_dfs/ui/__init__.py
+++ b/src/three_dfs/ui/__init__.py
@@ -1,0 +1,7 @@
+"""Reusable UI widgets for the 3dfs shell."""
+
+from __future__ import annotations
+
+from .tag_sidebar import TagSidebar
+
+__all__ = ["TagSidebar"]

--- a/src/three_dfs/ui/tag_sidebar.py
+++ b/src/three_dfs/ui/tag_sidebar.py
@@ -1,0 +1,275 @@
+"""Sidebar widget for managing repository tags."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Signal, Slot
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..data import TagStore
+
+__all__ = ["TagSidebar"]
+
+
+class TagSidebar(QWidget):
+    """Widget exposing CRUD utilities for tags.
+
+    The sidebar keeps the tag list for an "active" repository item in sync with
+    :class:`~three_dfs.data.tags.TagStore` and emits signals whenever the user
+    performs an operation so that other application components can react.
+    """
+
+    activeItemChanged = Signal(object)
+    """Emitted whenever the focused repository item changes."""
+
+    tagAdded = Signal(str, str)
+    """Emitted when a tag is created for the active item."""
+
+    tagRemoved = Signal(str, str)
+    """Emitted when a tag is deleted from the active item."""
+
+    tagRenamed = Signal(str, str, str)
+    """Emitted when a tag is renamed for the active item."""
+
+    tagsChanged = Signal(str, list)
+    """Emitted for any change that affects the active item's tag collection."""
+
+    searchRequested = Signal(str)
+    """Emitted whenever the search query text changes."""
+
+    def __init__(
+        self,
+        store: TagStore | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._store = store or TagStore()
+        self._active_item: str | None = None
+        self._all_tags_for_item: list[str] = []
+
+        self._title_label = QLabel("Tags", self)
+        self._title_label.setObjectName("tagSidebarTitle")
+
+        self._active_label = QLabel("No item selected", self)
+        self._active_label.setObjectName("tagSidebarActiveItem")
+
+        self._search_input = QLineEdit(self)
+        self._search_input.setPlaceholderText("Search tags…")
+        self._search_input.textChanged.connect(self._handle_search_changed)
+
+        self._tag_list = QListWidget(self)
+        self._tag_list.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._tag_list.itemSelectionChanged.connect(self._update_ui_state)
+        self._tag_list.itemDoubleClicked.connect(self._handle_item_double_clicked)
+
+        self._add_button = QPushButton("Add", self)
+        self._add_button.clicked.connect(self._handle_add_tag)
+
+        self._edit_button = QPushButton("Edit", self)
+        self._edit_button.clicked.connect(self._handle_edit_tag)
+
+        self._delete_button = QPushButton("Delete", self)
+        self._delete_button.clicked.connect(self._handle_delete_tag)
+
+        self._build_layout()
+        self._update_ui_state()
+
+    # ------------------------------------------------------------------
+    # Qt API surface
+    # ------------------------------------------------------------------
+    @Slot(object)
+    def set_active_item(self, item_id: str | None) -> None:
+        """Switch the sidebar context to *item_id* and refresh the view."""
+
+        if item_id == self._active_item:
+            # Refresh the view even when the identifier did not change.  This
+            # allows external callers to force a reload after out-of-band
+            # modifications.
+            self._load_tags_for_active_item()
+            self._emit_tags_changed()
+            return
+
+        self._active_item = item_id
+        self._load_tags_for_active_item()
+        self.activeItemChanged.emit(item_id)
+        self._emit_tags_changed()
+
+    def active_item(self) -> str | None:
+        """Return the identifier of the item currently being edited."""
+
+        return self._active_item
+
+    def tags(self) -> list[str]:
+        """Return the list of tags for the active item."""
+
+        return list(self._all_tags_for_item)
+
+    def search_text(self) -> str:
+        """Return the current search query."""
+
+        return self._search_input.text()
+
+    # ------------------------------------------------------------------
+    # Internal wiring
+    # ------------------------------------------------------------------
+    def _build_layout(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(6)
+
+        layout.addWidget(self._title_label)
+        layout.addWidget(self._active_label)
+        layout.addWidget(self._search_input)
+        layout.addWidget(self._tag_list, 1)
+
+        button_row = QHBoxLayout()
+        button_row.setSpacing(4)
+        button_row.addWidget(self._add_button)
+        button_row.addWidget(self._edit_button)
+        button_row.addWidget(self._delete_button)
+
+        layout.addLayout(button_row)
+
+    def _handle_search_changed(self, text: str) -> None:
+        self._refresh_visible_tags()
+        self.searchRequested.emit(text)
+
+    def _handle_item_double_clicked(self, item: QListWidgetItem) -> None:
+        if item is None:
+            return
+        self._handle_edit_tag()
+
+    def _handle_add_tag(self) -> None:
+        if self._active_item is None:
+            return
+
+        new_tag, accepted = QInputDialog.getText(self, "Create tag", "Tag name:")
+        if not accepted:
+            return
+
+        new_tag = new_tag.strip()
+        if not new_tag:
+            return
+
+        try:
+            normalized = self._store.add_tag(self._active_item, new_tag)
+        except ValueError:
+            return
+
+        if normalized is None:
+            return
+
+        self.tagAdded.emit(self._active_item, normalized)
+        self._load_tags_for_active_item()
+        self._emit_tags_changed()
+
+    def _handle_edit_tag(self) -> None:
+        if self._active_item is None:
+            return
+
+        current_item = self._tag_list.currentItem()
+        if current_item is None:
+            return
+
+        current_value = current_item.text()
+        new_tag, accepted = QInputDialog.getText(
+            self,
+            "Rename tag",
+            "New tag name:",
+            text=current_value,
+        )
+
+        if not accepted:
+            return
+
+        new_tag = new_tag.strip()
+        if not new_tag or new_tag == current_value:
+            return
+
+        try:
+            normalized = self._store.rename_tag(
+                self._active_item,
+                current_value,
+                new_tag,
+            )
+        except ValueError:
+            return
+
+        if normalized is None:
+            return
+
+        self.tagRenamed.emit(self._active_item, current_value, normalized)
+        self._load_tags_for_active_item()
+        self._emit_tags_changed()
+
+    def _handle_delete_tag(self) -> None:
+        if self._active_item is None:
+            return
+
+        current_item = self._tag_list.currentItem()
+        if current_item is None:
+            return
+
+        tag_value = current_item.text()
+        try:
+            removed = self._store.remove_tag(self._active_item, tag_value)
+        except ValueError:
+            return
+
+        if not removed:
+            return
+
+        self.tagRemoved.emit(self._active_item, tag_value)
+        self._load_tags_for_active_item()
+        self._emit_tags_changed()
+
+    def _load_tags_for_active_item(self) -> None:
+        if self._active_item is None:
+            self._active_label.setText("No item selected")
+            self._all_tags_for_item = []
+        else:
+            self._active_label.setText(f"Tags for {self._active_item}")
+            self._all_tags_for_item = self._store.tags_for(self._active_item)
+
+        self._refresh_visible_tags()
+        self._update_ui_state()
+
+    def _refresh_visible_tags(self) -> None:
+        self._tag_list.clear()
+        search_text = self._search_input.text().strip().casefold()
+
+        if search_text:
+            tags = [
+                tag for tag in self._all_tags_for_item if search_text in tag.casefold()
+            ]
+        else:
+            tags = list(self._all_tags_for_item)
+
+        for tag in tags:
+            self._tag_list.addItem(tag)
+
+    def _update_ui_state(self) -> None:
+        has_item = self._active_item is not None
+        has_selection = self._tag_list.currentItem() is not None
+
+        self._tag_list.setEnabled(has_item)
+        self._add_button.setEnabled(has_item)
+        self._edit_button.setEnabled(has_item and has_selection)
+        self._delete_button.setEnabled(has_item and has_selection)
+
+    def _emit_tags_changed(self) -> None:
+        if self._active_item is None:
+            return
+
+        tags = self._store.tags_for(self._active_item)
+        self.tagsChanged.emit(self._active_item, tags)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,46 @@
+"""Tests for the tag persistence layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from three_dfs.data.tags import TagStore
+
+
+def test_tag_store_add_remove_rename(tmp_path: Path) -> None:
+    store_path = tmp_path / "tags.json"
+    store = TagStore(store_path)
+
+    assert store.tags_for("item-1") == []
+
+    added = store.add_tag("item-1", "First")
+    assert added == "First"
+    assert store.tags_for("item-1") == ["First"]
+
+    # Duplicate addition returns None but does not raise.
+    assert store.add_tag("item-1", "First") is None
+
+    # Renaming the tag should persist.
+    renamed = store.rename_tag("item-1", "First", "Renamed")
+    assert renamed == "Renamed"
+    assert store.tags_for("item-1") == ["Renamed"]
+
+    # Removing the tag clears the item entry entirely.
+    removed = store.remove_tag("item-1", "Renamed")
+    assert removed is True
+    assert store.tags_for("item-1") == []
+
+
+def test_tag_store_persistence_roundtrip(tmp_path: Path) -> None:
+    store_path = tmp_path / "tags.json"
+    store = TagStore(store_path)
+
+    store.add_tag("foo", "Bar")
+    store.add_tag("foo", "Baz")
+    store.add_tag("qux", "Bar")
+
+    # A new instance pointing to the same file should read the state back.
+    reloaded = TagStore(store_path)
+    assert reloaded.tags_for("foo") == ["Bar", "Baz"]
+    assert reloaded.search("bar") == {"foo": ["Bar"], "qux": ["Bar"]}
+    assert set(reloaded.all_tags()) == {"Bar", "Baz"}


### PR DESCRIPTION
## Summary
- add a JSON-backed `TagStore` for loading, saving, and searching tags
- create a `TagSidebar` widget with editing controls and signals for tag changes/searches
- embed the sidebar in the main window and filter the repository list based on tag queries

## Testing
- PYTHONPATH=src pytest
- ruff check src tests

------
https://chatgpt.com/codex/tasks/task_e_68cb168310bc8325b2c6f935c35ca443