### PR TITLE
Add SQLAlchemy ORM models and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
   "PySide6>=6.7",
   "Pillow>=10.3",
+  "SQLAlchemy>=2.0",
 ]
 
 [tool.hatch.build.targets.sdist]
@@ -40,6 +41,7 @@ dependencies = [
   "pytest-cov>=4.1",
   "ruff>=0.4.2",
   "black>=24.3.0",
+  "SQLAlchemy>=2.0",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/src/three_dfs/db/__init__.py
+++ b/src/three_dfs/db/__init__.py
@@ -1,0 +1,33 @@
+"""Database bootstrap helpers and ORM models for the 3dfs package."""
+
+from .models import (
+    DEFAULT_DATABASE_URL,
+    Asset,
+    Attachment,
+    AuditLog,
+    Base,
+    PrinterProfile,
+    SessionLocal,
+    Tag,
+    Version,
+    asset_tag_table,
+    create_session_factory,
+    get_engine,
+    metadata,
+)
+
+__all__ = [
+    "Attachment",
+    "AuditLog",
+    "Asset",
+    "Base",
+    "DEFAULT_DATABASE_URL",
+    "PrinterProfile",
+    "SessionLocal",
+    "Tag",
+    "Version",
+    "asset_tag_table",
+    "create_session_factory",
+    "get_engine",
+    "metadata",
+]

--- a/src/three_dfs/db/models.py
+++ b/src/three_dfs/db/models.py
@@ -1,0 +1,308 @@
+"""Database schema definitions for the 3dfs application.
+
+This module centralises the SQLAlchemy declarative mappings used throughout the
+project.  The schema models the core asset management concepts:
+
+* :class:`Asset` – the top-level entity that groups printable resources.
+* :class:`Version` – a concrete revision of an asset along with metadata.
+* :class:`Attachment` – supplemental files (e.g., STL previews) linked to a
+  version.
+* :class:`Tag` – user defined labels that can be attached to assets via a
+  many-to-many association table.
+* :class:`PrinterProfile` – reusable printer settings that can be referenced
+  by versions.
+* :class:`AuditLog` – append-only records describing actions performed on an
+  asset.
+
+Alongside the ORM mappings the module provides helpers for instantiating a
+SQLite-backed engine, constructing sessions, and accessing the shared
+:class:`sqlalchemy.schema.MetaData` instance.  Tests and runtime code can rely on
+``get_engine``/``create_session_factory`` to bootstrap the database without
+having to duplicate configuration boilerplate.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+    Text,
+    UniqueConstraint,
+    create_engine,
+    event,
+)
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    Session,
+    mapped_column,
+    relationship,
+    sessionmaker,
+)
+
+DEFAULT_DATABASE_URL = "sqlite+pysqlite:///:memory:"
+"""Default connection string used for in-memory testing and local usage."""
+
+
+def _utcnow() -> datetime:
+    """Return an aware UTC timestamp used by default for temporal columns."""
+
+    return datetime.now(UTC)
+
+
+class Base(DeclarativeBase):
+    """Base class for all ORM models within the 3dfs database schema."""
+
+
+metadata = Base.metadata
+"""Exposed metadata object for migrations and table management."""
+
+
+def _configure_sqlite_pragma(engine: Engine) -> None:
+    """Ensure SQLite engines enforce foreign key constraints."""
+
+    if engine.url.get_backend_name() != "sqlite":
+        return
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection, _connection_record) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA foreign_keys=ON")
+        finally:
+            cursor.close()
+
+
+def _create_engine(url: str, **kwargs: Any) -> Engine:
+    """Create a configured SQLAlchemy engine and enable SQLite pragmas."""
+
+    engine = create_engine(url, future=True, **kwargs)
+    _configure_sqlite_pragma(engine)
+    return engine
+
+
+_DEFAULT_ENGINE: Engine = _create_engine(DEFAULT_DATABASE_URL)
+"""Module-level default engine reused by :func:`get_engine`."""
+
+
+def get_engine(url: str | None = None, **kwargs: Any) -> Engine:
+    """Return a configured SQLAlchemy engine.
+
+    Parameters
+    ----------
+    url:
+        Optional database URL. When omitted the shared in-memory SQLite engine
+        is returned.
+    **kwargs:
+        Additional keyword arguments forwarded to :func:`sqlalchemy.create_engine`.
+    """
+
+    if url is None and not kwargs:
+        return _DEFAULT_ENGINE
+
+    actual_url = url or DEFAULT_DATABASE_URL
+    return _create_engine(actual_url, **kwargs)
+
+
+def create_session_factory(
+    engine: Engine | None = None,
+    *,
+    expire_on_commit: bool = False,
+    autoflush: bool = False,
+) -> sessionmaker[Session]:
+    """Return a ``sessionmaker`` bound to the supplied engine.
+
+    The helper mirrors the default configuration used by :data:`SessionLocal`
+    which keeps objects live after commits.  Passing an explicit engine allows
+    tests to operate on isolated databases.
+    """
+
+    bound_engine = engine or get_engine()
+    return sessionmaker(
+        bind=bound_engine,
+        expire_on_commit=expire_on_commit,
+        autoflush=autoflush,
+        future=True,
+    )
+
+
+SessionLocal = create_session_factory()
+"""Ready-to-use session factory bound to the default engine."""
+
+
+asset_tag_table = Table(
+    "asset_tags",
+    metadata,
+    Column("asset_id", ForeignKey("assets.id", ondelete="CASCADE"), primary_key=True),
+    Column("tag_id", ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True),
+    UniqueConstraint("asset_id", "tag_id", name="uq_asset_tag"),
+)
+"""Association table linking :class:`Asset` and :class:`Tag` records."""
+
+
+class Asset(Base):
+    """Top-level entity describing a printable asset and its relationships."""
+
+    __tablename__ = "assets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow, nullable=False
+    )
+
+    versions: Mapped[list[Version]] = relationship(
+        back_populates="asset",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        order_by="Version.number",
+    )
+    tags: Mapped[list[Tag]] = relationship(
+        secondary=lambda: asset_tag_table,
+        back_populates="assets",
+    )
+    audit_logs: Mapped[list[AuditLog]] = relationship(
+        back_populates="asset",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        order_by="desc(AuditLog.created_at)",
+    )
+
+
+class Version(Base):
+    """Concrete revision of an asset with optional printer profile linkage."""
+
+    __tablename__ = "versions"
+    __table_args__ = (
+        UniqueConstraint("asset_id", "number", name="uq_version_number_per_asset"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    asset_id: Mapped[int] = mapped_column(
+        ForeignKey("assets.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    number: Mapped[int] = mapped_column(Integer, nullable=False)
+    label: Mapped[str] = mapped_column(String(128), nullable=False)
+    notes: Mapped[str | None] = mapped_column(Text())
+    printer_profile_id: Mapped[int | None] = mapped_column(
+        ForeignKey("printer_profiles.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        nullable=False,
+    )
+
+    asset: Mapped[Asset] = relationship(back_populates="versions")
+    attachments: Mapped[list[Attachment]] = relationship(
+        back_populates="version",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        order_by="Attachment.id",
+    )
+    printer_profile: Mapped[PrinterProfile | None] = relationship(
+        back_populates="versions"
+    )
+
+
+class Attachment(Base):
+    """File linked to a specific version (e.g. preview images or archives)."""
+
+    __tablename__ = "attachments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    version_id: Mapped[int] = mapped_column(
+        ForeignKey("versions.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    uri: Mapped[str] = mapped_column(String(512), nullable=False)
+    checksum: Mapped[str | None] = mapped_column(String(128))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        nullable=False,
+    )
+
+    version: Mapped[Version] = relationship(back_populates="attachments")
+
+
+class Tag(Base):
+    """User defined label that can be applied to multiple assets."""
+
+    __tablename__ = "tags"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text())
+
+    assets: Mapped[list[Asset]] = relationship(
+        secondary=lambda: asset_tag_table,
+        back_populates="tags",
+    )
+
+
+class PrinterProfile(Base):
+    """Reusable printer configuration referenced by asset versions."""
+
+    __tablename__ = "printer_profiles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
+    nozzle_diameter: Mapped[float | None] = mapped_column(Float())
+    material: Mapped[str | None] = mapped_column(String(64))
+    settings: Mapped[dict[str, Any] | None] = mapped_column(JSON())
+
+    versions: Mapped[list[Version]] = relationship(back_populates="printer_profile")
+
+
+class AuditLog(Base):
+    """Append-only log describing actions executed on assets."""
+
+    __tablename__ = "audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    asset_id: Mapped[int] = mapped_column(
+        ForeignKey("assets.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    action: Mapped[str] = mapped_column(String(64), nullable=False)
+    actor: Mapped[str | None] = mapped_column(String(64))
+    details: Mapped[str | None] = mapped_column(Text())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        nullable=False,
+    )
+
+    asset: Mapped[Asset] = relationship(back_populates="audit_logs")
+
+
+__all__ = [
+    "Attachment",
+    "AuditLog",
+    "Asset",
+    "Base",
+    "DEFAULT_DATABASE_URL",
+    "SessionLocal",
+    "Tag",
+    "Version",
+    "PrinterProfile",
+    "asset_tag_table",
+    "create_session_factory",
+    "get_engine",
+    "metadata",
+]

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -1,0 +1,149 @@
+"""Relationship and constraint tests for the SQLAlchemy ORM models."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from three_dfs.db import (
+    Asset,
+    Attachment,
+    AuditLog,
+    Base,
+    PrinterProfile,
+    Tag,
+    Version,
+    asset_tag_table,
+    create_session_factory,
+    get_engine,
+)
+
+
+@pytest.fixture()
+def engine(tmp_path):
+    """Create a temporary SQLite database for testing."""
+
+    db_path = tmp_path / "orm.sqlite"
+    engine = get_engine(f"sqlite+pysqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def session(engine):
+    """Yield a SQLAlchemy session bound to the temporary engine."""
+
+    SessionFactory = create_session_factory(engine)
+    db_session = SessionFactory()
+    try:
+        yield db_session
+    finally:
+        db_session.rollback()
+        db_session.close()
+
+
+def test_asset_version_and_attachment_cascade(session):
+    """Deleting an asset removes dependent versions, attachments, and logs."""
+
+    asset = Asset(name="Calibration Cube", description="Baseline test asset")
+    version = Version(number=1, label="Initial release")
+    version.attachments.append(
+        Attachment(kind="model", uri="file://cube-v1.stl", checksum="abc123")
+    )
+    asset.versions.append(version)
+    asset.audit_logs.append(AuditLog(action="create", actor="tester"))
+
+    session.add(asset)
+    session.commit()
+
+    stored_asset = session.get(Asset, asset.id)
+    assert stored_asset is not None
+    assert stored_asset.versions[0].attachments[0].uri.endswith("cube-v1.stl")
+
+    session.delete(stored_asset)
+    session.commit()
+
+    assert session.scalars(select(Version)).all() == []
+    assert session.scalars(select(Attachment)).all() == []
+    assert session.scalars(select(AuditLog)).all() == []
+
+
+def test_asset_tag_association(session):
+    """Assets expose tag relationships via the association table."""
+
+    asset = Asset(name="Widget Mk2")
+    featured = Tag(name="Featured")
+    material = Tag(name="PLA")
+    asset.tags.extend([featured, material])
+
+    session.add(asset)
+    session.commit()
+
+    stored_asset = session.get(Asset, asset.id)
+    assert stored_asset is not None
+    assert {tag.name for tag in stored_asset.tags} == {"Featured", "PLA"}
+
+    stored_asset.tags.remove(featured)
+    session.commit()
+
+    refreshed_asset = session.get(Asset, asset.id)
+    assert {tag.name for tag in refreshed_asset.tags} == {"PLA"}
+
+    with pytest.raises(IntegrityError):
+        session.execute(
+            asset_tag_table.insert().values(asset_id=asset.id, tag_id=material.id)
+        )
+    session.rollback()
+
+
+def test_version_number_unique_per_asset(session):
+    """Version numbers are unique per asset as enforced by the constraint."""
+
+    asset = Asset(name="Constraint Demo")
+    session.add(asset)
+    session.flush()
+
+    session.add(Version(number=1, label="Initial", asset=asset))
+    session.flush()
+
+    session.add(Version(number=1, label="Duplicate", asset=asset))
+    with pytest.raises(IntegrityError):
+        session.flush()
+    session.rollback()
+
+
+def test_printer_profile_relationship(session):
+    """Versions can reference printer profiles and nullify when deleted."""
+
+    profile = PrinterProfile(
+        name="Prusa MK3",
+        nozzle_diameter=0.4,
+        material="PLA",
+        settings={"temperature": 215},
+    )
+    asset = Asset(name="Calibration Fin")
+    version = Version(number=1, label="Profiled", printer_profile=profile)
+    asset.versions.append(version)
+
+    session.add(asset)
+    session.commit()
+
+    stored_version = session.get(Version, version.id)
+    assert stored_version is not None
+    assert stored_version.printer_profile is not None
+    assert stored_version.printer_profile.name == "Prusa MK3"
+    assert stored_version.printer_profile.settings == {"temperature": 215}
+
+    session.delete(profile)
+    session.commit()
+    session.expire_all()
+
+    refreshed_version = session.get(Version, version.id)
+    assert refreshed_version is not None
+    assert refreshed_version.printer_profile is None
+    assert refreshed_version.printer_profile_id is None


### PR DESCRIPTION
## Summary
- add SQLAlchemy as a runtime and development dependency so the ORM is available
- introduce a `three_dfs.db` package that configures a SQLite engine/session factory and maps asset management models
- write unit tests that exercise cascades, many-to-many associations, and uniqueness constraints for the new schema

## Testing
- PYTHONPATH=src pytest
- ruff check src tests

------
https://chatgpt.com/codex/tasks/task_e_68cb1a9d73708325b689ff312a8c507f