### PR TITLE
Add SQLite storage layer for assets and integrate with UI

### DIFF
--- a/src/three_dfs/data/tags.py
+++ b/src/three_dfs/data/tags.py
@@ -1,173 +1,96 @@
-"""Tag persistence helpers.
-
-This module provides a light-weight persistence layer for associating text
-labels ("tags") with arbitrary repository item identifiers.  The
-implementation is intentionally simple – a JSON file on disk – but exposes a
-clean API that higher level UI components can rely on.
-"""
+"""Tag persistence helpers backed by the asset storage layer."""
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 
-__all__ = ["TagStore"]
+from ..storage import AssetRepository, AssetService, SQLiteStorage
 
-DEFAULT_DATA_DIR = Path.home() / ".3dfs"
-DEFAULT_DATA_FILE = DEFAULT_DATA_DIR / "tags.json"
+__all__ = ["TagStore"]
 
 
 class TagStore:
-    """Persist and query tag assignments for repository items.
+    """Persist and query tag assignments for repository items."""
 
-    Parameters
-    ----------
-    path:
-        Optional location for the backing JSON file.  When omitted a file in
-        the user's home directory (``~/.3dfs/tags.json``) is used.
-    """
+    def __init__(
+        self,
+        path: str | Path | None = None,
+        *,
+        service: AssetService | None = None,
+    ) -> None:
+        if path is not None and service is not None:
+            raise ValueError("Provide either a database path or an AssetService, not both.")
 
-    def __init__(self, path: str | Path | None = None) -> None:
-        self._path = Path(path) if path is not None else DEFAULT_DATA_FILE
-        self._records: dict[str, list[str]] = {}
-        self._load()
+        if service is None:
+            storage = SQLiteStorage(path)
+            repository = AssetRepository(storage)
+            service = AssetService(repository)
+
+        self._service = service
+        self._repository = service.repository
 
     # ------------------------------------------------------------------
     # Basic helpers
     # ------------------------------------------------------------------
     @property
-    def path(self) -> Path:
-        """Return the resolved location of the persistence file."""
+    def path(self) -> Path | None:
+        """Return the resolved location of the SQLite database if persisted."""
 
-        return self._path
+        return self._repository.database_path
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
     def tags_for(self, item_id: str) -> list[str]:
-        """Return a copy of the tags assigned to *item_id*.
-
-        The returned list is always sorted alphabetically (case-insensitive)
-        and can be mutated by the caller without affecting the stored state.
-        """
+        """Return a copy of the tags assigned to *item_id*."""
 
         item_key = self._normalize_item_id(item_id)
-        tags = self._records.get(item_key, [])
-        return list(tags)
+        return self._service.tags_for_path(item_key)
 
     def set_tags(self, item_id: str, tags: Iterable[str]) -> list[str]:
-        """Replace the tags for *item_id* with *tags*.
-
-        Returns the normalized, sorted tag list that was persisted.
-        """
+        """Replace the tags for *item_id* with *tags*."""
 
         item_key = self._normalize_item_id(item_id)
         normalized = self._normalize_tag_iterable(tags)
-
-        if normalized:
-            self._records[item_key] = normalized
-        else:
-            self._records.pop(item_key, None)
-
-        self._save()
-        return list(normalized)
+        return self._service.set_tags(item_key, normalized)
 
     def add_tag(self, item_id: str, tag: str) -> str | None:
-        """Add *tag* to *item_id* and return the normalized value.
-
-        ``None`` is returned when the tag already exists for the item.
-        """
+        """Add *tag* to *item_id* and return the normalized value."""
 
         item_key = self._normalize_item_id(item_id)
         normalized = self._normalize_tag(tag)
-        tags = self._records.setdefault(item_key, [])
-
-        if normalized in tags:
-            return None
-
-        tags.append(normalized)
-        tags.sort(key=str.casefold)
-        self._save()
-        return normalized
+        return self._service.add_tag(item_key, normalized)
 
     def remove_tag(self, item_id: str, tag: str) -> bool:
         """Remove *tag* from *item_id* if present."""
 
         item_key = self._normalize_item_id(item_id)
         normalized = self._normalize_tag(tag)
-        tags = self._records.get(item_key)
-
-        if not tags or normalized not in tags:
-            return False
-
-        tags.remove(normalized)
-
-        if tags:
-            tags.sort(key=str.casefold)
-        else:
-            del self._records[item_key]
-
-        self._save()
-        return True
+        return self._service.remove_tag(item_key, normalized)
 
     def rename_tag(self, item_id: str, old_tag: str, new_tag: str) -> str | None:
-        """Rename *old_tag* to *new_tag* for *item_id*.
-
-        The normalized new tag name is returned on success.  ``None`` is
-        returned when *old_tag* does not exist for the item or when *new_tag*
-        would collide with an existing entry.
-        """
+        """Rename *old_tag* to *new_tag* for *item_id*."""
 
         item_key = self._normalize_item_id(item_id)
-        tags = self._records.get(item_key)
-
-        if not tags:
-            return None
-
         old_normalized = self._normalize_tag(old_tag)
-        if old_normalized not in tags:
-            return None
-
         new_normalized = self._normalize_tag(new_tag)
-
-        if new_normalized in tags and new_normalized != old_normalized:
-            return None
-
-        index = tags.index(old_normalized)
-        tags[index] = new_normalized
-        tags.sort(key=str.casefold)
-        self._save()
-        return new_normalized
+        return self._service.rename_tag(item_key, old_normalized, new_normalized)
 
     def search(self, query: str) -> dict[str, list[str]]:
         """Return all tags whose text contains *query* (case-insensitive)."""
 
-        needle = str(query or "").strip().casefold()
-
-        if not needle:
-            return {item_id: list(tags) for item_id, tags in self._records.items()}
-
-        results: dict[str, list[str]] = {}
-
-        for item_id, tags in self._records.items():
-            matches = [tag for tag in tags if needle in tag.casefold()]
-            if matches:
-                results[item_id] = matches
-
-        return results
+        return self._service.search_tags(query)
 
     def all_tags(self) -> list[str]:
         """Return a sorted list of every tag stored for any item."""
 
-        universe = {tag for tags in self._records.values() for tag in tags}
-        return sorted(universe, key=str.casefold)
+        return self._service.all_tags()
 
     def iter_items(self) -> Iterator[tuple[str, list[str]]]:
         """Yield ``(item_id, tags)`` pairs for every stored item."""
 
-        for item_id, tags in self._records.items():
-            yield item_id, list(tags)
+        yield from self._service.iter_tagged_assets()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -190,52 +113,3 @@ class TagStore:
             normalized = self._normalize_tag(tag)
             unique.setdefault(normalized, None)
         return sorted(unique.keys(), key=str.casefold)
-
-    def _load(self) -> None:
-        if not self._path.exists():
-            self._records = {}
-            return
-
-        try:
-            with self._path.open("r", encoding="utf8") as handle:
-                payload = json.load(handle)
-        except (OSError, json.JSONDecodeError):
-            self._records = {}
-            return
-
-        items = payload.get("items") if isinstance(payload, dict) else None
-        if not isinstance(items, dict):
-            self._records = {}
-            return
-
-        records: dict[str, list[str]] = {}
-
-        for item_id, tags in items.items():
-            if not isinstance(tags, list):
-                continue
-
-            key = str(item_id)
-            normalized_tags = [
-                str(tag).strip() for tag in tags if str(tag).strip()
-            ]
-
-            if normalized_tags:
-                records[key] = sorted(set(normalized_tags), key=str.casefold)
-
-        self._records = records
-
-    def _save(self) -> None:
-        if not self._records:
-            # Remove the file entirely when no tags remain to avoid leaving
-            # behind empty JSON files.
-            try:
-                self._path.unlink()
-            except FileNotFoundError:
-                pass
-            return
-
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {"items": self._records}
-
-        with self._path.open("w", encoding="utf8") as handle:
-            json.dump(payload, handle, indent=2, sort_keys=True)

--- a/src/three_dfs/storage/__init__.py
+++ b/src/three_dfs/storage/__init__.py
@@ -1,0 +1,14 @@
+"""SQLite-backed persistence utilities for 3dfs asset metadata."""
+
+from .database import DEFAULT_DB_PATH, SQLiteStorage
+from .repository import AssetRecord, AssetRepository
+from .service import AssetSeed, AssetService
+
+__all__ = [
+    "AssetRecord",
+    "AssetRepository",
+    "AssetSeed",
+    "AssetService",
+    "DEFAULT_DB_PATH",
+    "SQLiteStorage",
+]

--- a/src/three_dfs/storage/database.py
+++ b/src/three_dfs/storage/database.py
@@ -1,0 +1,76 @@
+"""Low level SQLite helpers for the 3dfs storage package."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_DB_FILENAME = "assets.sqlite3"
+DEFAULT_DB_PATH = Path.home() / ".3dfs" / DEFAULT_DB_FILENAME
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS assets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    path TEXT NOT NULL UNIQUE,
+    label TEXT NOT NULL,
+    metadata TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS asset_tags (
+    asset_id INTEGER NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+    tag TEXT NOT NULL COLLATE NOCASE,
+    PRIMARY KEY (asset_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_asset_tags_tag ON asset_tags(tag);
+"""
+
+
+class SQLiteStorage:
+    """Encapsulate access to the on-disk SQLite database."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        raw_path = path or DEFAULT_DB_PATH
+
+        if isinstance(raw_path, Path):
+            raw_path = raw_path.expanduser()
+
+        if str(raw_path) == ":memory:":
+            self._database = ":memory:"
+            self._path: Optional[Path] = None
+        else:
+            actual_path = Path(raw_path).expanduser()
+            actual_path.parent.mkdir(parents=True, exist_ok=True)
+            self._database = str(actual_path)
+            self._path = actual_path
+
+        self._initialize_schema()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def path(self) -> Optional[Path]:
+        """Return the filesystem location for the database if persisted."""
+
+        return self._path
+
+    def connect(self) -> sqlite3.Connection:
+        """Return a new SQLite connection with required pragmas applied."""
+
+        connection = sqlite3.connect(self._database)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _initialize_schema(self) -> None:
+        """Ensure the schema is created for the target database."""
+
+        with self.connect() as connection:
+            connection.executescript(SCHEMA)

--- a/src/three_dfs/storage/repository.py
+++ b/src/three_dfs/storage/repository.py
@@ -1,0 +1,489 @@
+"""Repository classes wrapping raw SQLite access for assets and tags."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from sqlite3 import Connection
+from typing import Any, Iterable, Iterator, Mapping
+
+from .database import SQLiteStorage
+
+__all__ = ["AssetRecord", "AssetRepository"]
+
+
+@dataclass(slots=True)
+class AssetRecord:
+    """In-memory representation of an asset persisted in SQLite."""
+
+    id: int
+    path: str
+    label: str
+    metadata: dict[str, Any]
+    tags: list[str]
+    created_at: datetime
+    updated_at: datetime
+
+
+_MISSING = object()
+
+
+class AssetRepository:
+    """Provide CRUD operations for :class:`AssetRecord` instances."""
+
+    def __init__(self, storage: SQLiteStorage | None = None) -> None:
+        self._storage = storage or SQLiteStorage()
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+    @property
+    def storage(self) -> SQLiteStorage:
+        """Return the underlying storage engine."""
+
+        return self._storage
+
+    @property
+    def database_path(self) -> Path | None:
+        """Return the filesystem path to the SQLite database if available."""
+
+        return self._storage.path
+
+    # ------------------------------------------------------------------
+    # Asset CRUD operations
+    # ------------------------------------------------------------------
+    def create_asset(
+        self,
+        path: str,
+        *,
+        label: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        tags: Iterable[str] | None = None,
+    ) -> AssetRecord:
+        """Create a new asset record and return the hydrated entity."""
+
+        normalized_path = self._normalize_path(path)
+        now = datetime.now(UTC)
+        serialized_metadata = self._serialize_metadata(metadata)
+        normalized_label = label or normalized_path
+        normalized_tags = self._normalize_tags(tags or [])
+
+        with self._storage.connect() as connection:
+            cursor = connection.execute(
+                """
+                INSERT INTO assets(path, label, metadata, created_at, updated_at)
+                VALUES(?, ?, ?, ?, ?)
+                """,
+                (
+                    normalized_path,
+                    normalized_label,
+                    serialized_metadata,
+                    now.isoformat(),
+                    now.isoformat(),
+                ),
+            )
+            asset_id = cursor.lastrowid
+            if normalized_tags:
+                self._replace_tags(connection, asset_id, normalized_tags)
+            row = self._fetch_asset_row(connection, asset_id)
+            tags_for_asset = self._fetch_tags(connection, asset_id)
+
+        return self._row_to_record(row, tags_for_asset)
+
+    def ensure_asset(
+        self,
+        path: str,
+        *,
+        label: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AssetRecord:
+        """Return an existing asset for *path* or create a placeholder."""
+
+        existing = self.get_asset_by_path(path)
+        if existing is not None:
+            return existing
+        return self.create_asset(path, label=label or path, metadata=metadata)
+
+    def get_asset(self, asset_id: int) -> AssetRecord | None:
+        """Return the asset identified by *asset_id* if it exists."""
+
+        with self._storage.connect() as connection:
+            row = self._fetch_asset_row(connection, asset_id)
+            if row is None:
+                return None
+            tags = self._fetch_tags(connection, asset_id)
+        return self._row_to_record(row, tags)
+
+    def get_asset_by_path(self, path: str) -> AssetRecord | None:
+        """Return the asset identified by *path* if present."""
+
+        normalized_path = self._normalize_path(path)
+        with self._storage.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM assets WHERE path = ?",
+                (normalized_path,),
+            ).fetchone()
+            if row is None:
+                return None
+            tags = self._fetch_tags(connection, row["id"])
+        return self._row_to_record(row, tags)
+
+    def list_assets(self) -> list[AssetRecord]:
+        """Return every stored asset ordered by path."""
+
+        with self._storage.connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM assets ORDER BY path COLLATE NOCASE"
+            ).fetchall()
+            return self._rows_to_records(connection, rows)
+
+    def update_asset(
+        self,
+        asset_id: int,
+        *,
+        path: str | None = None,
+        label: str | None = None,
+        metadata: Mapping[str, Any] | None | object = _MISSING,
+        tags: Iterable[str] | None | object = _MISSING,
+    ) -> AssetRecord:
+        """Apply updates to an asset and return the refreshed entity."""
+
+        updates: list[str] = []
+        params: list[Any] = []
+
+        if path is not None:
+            updates.append("path = ?")
+            params.append(self._normalize_path(path))
+        if label is not None:
+            updates.append("label = ?")
+            params.append(label)
+        if metadata is not _MISSING:
+            updates.append("metadata = ?")
+            params.append(self._serialize_metadata(metadata))
+
+        now = datetime.now(UTC)
+
+        with self._storage.connect() as connection:
+            if updates:
+                updates.append("updated_at = ?")
+                params.append(now.isoformat())
+                params.append(asset_id)
+                connection.execute(
+                    f"UPDATE assets SET {', '.join(updates)} WHERE id = ?",
+                    params,
+                )
+
+            if tags is not _MISSING:
+                normalized_tags = self._normalize_tags(tags or [])
+                self._replace_tags(connection, asset_id, normalized_tags)
+                if not updates:
+                    connection.execute(
+                        "UPDATE assets SET updated_at = ? WHERE id = ?",
+                        (now.isoformat(), asset_id),
+                    )
+
+            row = self._fetch_asset_row(connection, asset_id)
+            if row is None:
+                raise KeyError(f"Asset {asset_id} does not exist")
+            tags_for_asset = self._fetch_tags(connection, asset_id)
+
+        return self._row_to_record(row, tags_for_asset)
+
+    def delete_asset(self, asset_id: int) -> bool:
+        """Delete an asset by identifier."""
+
+        with self._storage.connect() as connection:
+            cursor = connection.execute(
+                "DELETE FROM assets WHERE id = ?",
+                (asset_id,),
+            )
+            return cursor.rowcount > 0
+
+    def delete_asset_by_path(self, path: str) -> bool:
+        """Delete an asset matching *path* if present."""
+
+        normalized_path = self._normalize_path(path)
+        with self._storage.connect() as connection:
+            cursor = connection.execute(
+                "DELETE FROM assets WHERE path = ?",
+                (normalized_path,),
+            )
+            return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Tag operations
+    # ------------------------------------------------------------------
+    def set_tags(self, asset_id: int, tags: Iterable[str]) -> list[str]:
+        """Replace all tags for *asset_id* with *tags*."""
+
+        normalized_tags = self._normalize_tags(tags)
+        now = datetime.now(UTC)
+
+        with self._storage.connect() as connection:
+            self._replace_tags(connection, asset_id, normalized_tags)
+            connection.execute(
+                "UPDATE assets SET updated_at = ? WHERE id = ?",
+                (now.isoformat(), asset_id),
+            )
+            return list(normalized_tags)
+
+    def add_tag(self, asset_id: int, tag: str) -> str | None:
+        """Add *tag* to *asset_id* returning the normalized value."""
+
+        normalized_tag = self._normalize_tag(tag)
+        now = datetime.now(UTC)
+
+        with self._storage.connect() as connection:
+            cursor = connection.execute(
+                """
+                INSERT OR IGNORE INTO asset_tags(asset_id, tag)
+                VALUES(?, ?)
+                """,
+                (asset_id, normalized_tag),
+            )
+            if cursor.rowcount:
+                connection.execute(
+                    "UPDATE assets SET updated_at = ? WHERE id = ?",
+                    (now.isoformat(), asset_id),
+                )
+                return normalized_tag
+            return None
+
+    def remove_tag(self, asset_id: int, tag: str) -> bool:
+        """Remove *tag* from the asset if present."""
+
+        normalized_tag = self._normalize_tag(tag)
+
+        with self._storage.connect() as connection:
+            cursor = connection.execute(
+                "DELETE FROM asset_tags WHERE asset_id = ? AND tag = ?",
+                (asset_id, normalized_tag),
+            )
+            if cursor.rowcount:
+                connection.execute(
+                    "UPDATE assets SET updated_at = ? WHERE id = ?",
+                    (datetime.now(UTC).isoformat(), asset_id),
+                )
+                return True
+            return False
+
+    def rename_tag(self, asset_id: int, old_tag: str, new_tag: str) -> str | None:
+        """Rename *old_tag* to *new_tag* for the given asset."""
+
+        normalized_old = self._normalize_tag(old_tag)
+        normalized_new = self._normalize_tag(new_tag)
+
+        with self._storage.connect() as connection:
+            existing = connection.execute(
+                "SELECT 1 FROM asset_tags WHERE asset_id = ? AND tag = ?",
+                (asset_id, normalized_old),
+            ).fetchone()
+            if existing is None:
+                return None
+
+            collision = connection.execute(
+                "SELECT 1 FROM asset_tags WHERE asset_id = ? AND tag = ?",
+                (asset_id, normalized_new),
+            ).fetchone()
+            if collision and normalized_new != normalized_old:
+                return None
+
+            connection.execute(
+                """
+                UPDATE asset_tags SET tag = ?
+                WHERE asset_id = ? AND tag = ?
+                """,
+                (normalized_new, asset_id, normalized_old),
+            )
+            connection.execute(
+                "UPDATE assets SET updated_at = ? WHERE id = ?",
+                (datetime.now(UTC).isoformat(), asset_id),
+            )
+            return normalized_new
+
+    def tags_for_path(self, path: str) -> list[str]:
+        """Return the tags associated with *path*."""
+
+        asset = self.get_asset_by_path(path)
+        if asset is None:
+            return []
+        return list(asset.tags)
+
+    def search_tags(self, query: str) -> dict[str, list[str]]:
+        """Return assets whose tag text contains *query* (case-insensitive)."""
+
+        needle = str(query or "").strip().casefold()
+        results: dict[str, list[str]] = {}
+
+        with self._storage.connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT assets.path AS path, asset_tags.tag AS tag
+                FROM assets
+                JOIN asset_tags ON asset_tags.asset_id = assets.id
+                ORDER BY assets.path COLLATE NOCASE, asset_tags.tag COLLATE NOCASE
+                """
+            ).fetchall()
+
+        for row in rows:
+            tag = str(row["tag"])
+            if needle and needle not in tag.casefold():
+                continue
+            results.setdefault(str(row["path"]), []).append(tag)
+
+        return results
+
+    def all_tags(self) -> list[str]:
+        """Return every tag stored across all assets."""
+
+        with self._storage.connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT DISTINCT tag FROM asset_tags
+                ORDER BY tag COLLATE NOCASE
+                """
+            ).fetchall()
+            return [str(row["tag"]) for row in rows]
+
+    def iter_tagged_assets(self) -> Iterator[tuple[str, list[str]]]:
+        """Yield ``(path, tags)`` pairs for assets with assigned tags."""
+
+        with self._storage.connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT assets.path AS path, asset_tags.tag AS tag
+                FROM assets
+                JOIN asset_tags ON asset_tags.asset_id = assets.id
+                ORDER BY assets.path COLLATE NOCASE, asset_tags.tag COLLATE NOCASE
+                """
+            ).fetchall()
+
+        current_path: str | None = None
+        bucket: list[str] = []
+
+        for row in rows:
+            path = str(row["path"])
+            tag = str(row["tag"])
+            if current_path is None:
+                current_path = path
+            if path != current_path:
+                yield current_path, list(bucket)
+                current_path = path
+                bucket = [tag]
+            else:
+                bucket.append(tag)
+
+        if current_path is not None:
+            yield current_path, list(bucket)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _normalize_path(self, path: str) -> str:
+        value = str(path).strip()
+        if not value:
+            raise ValueError("Asset path cannot be empty")
+        return value
+
+    def _normalize_tag(self, tag: str) -> str:
+        value = str(tag).strip()
+        if not value:
+            raise ValueError("Tags must contain visible characters")
+        return value
+
+    def _normalize_tags(self, tags: Iterable[str]) -> list[str]:
+        seen: dict[str, None] = {}
+        for tag in tags:
+            normalized = self._normalize_tag(tag)
+            seen.setdefault(normalized, None)
+        return sorted(seen, key=str.casefold)
+
+    def _serialize_metadata(self, metadata: Mapping[str, Any] | None | object) -> str:
+        if metadata is None or metadata is _MISSING:
+            return json.dumps({})
+        return json.dumps(dict(metadata))
+
+    def _fetch_asset_row(self, connection: Connection, asset_id: int):
+        return connection.execute(
+            "SELECT * FROM assets WHERE id = ?",
+            (asset_id,),
+        ).fetchone()
+
+    def _fetch_tags(self, connection: Connection, asset_id: int) -> list[str]:
+        rows = connection.execute(
+            """
+            SELECT tag FROM asset_tags WHERE asset_id = ?
+            ORDER BY tag COLLATE NOCASE
+            """,
+            (asset_id,),
+        ).fetchall()
+        return [str(row["tag"]) for row in rows]
+
+    def _rows_to_records(self, connection: Connection, rows) -> list[AssetRecord]:
+        if not rows:
+            return []
+        asset_ids = [row["id"] for row in rows]
+        tags_map = self._tags_for_asset_ids(connection, asset_ids)
+        return [
+            self._row_to_record(row, tags_map.get(row["id"], []))
+            for row in rows
+        ]
+
+    def _tags_for_asset_ids(
+        self, connection: Connection, asset_ids: list[int]
+    ) -> dict[int, list[str]]:
+        if not asset_ids:
+            return {}
+        placeholders = ",".join(["?"] * len(asset_ids))
+        rows = connection.execute(
+            f"""
+            SELECT asset_id, tag
+            FROM asset_tags
+            WHERE asset_id IN ({placeholders})
+            ORDER BY asset_id, tag COLLATE NOCASE
+            """,
+            asset_ids,
+        ).fetchall()
+        tags_map: dict[int, list[str]] = {asset_id: [] for asset_id in asset_ids}
+        for row in rows:
+            tags_map.setdefault(row["asset_id"], []).append(str(row["tag"]))
+        return tags_map
+
+    def _row_to_record(self, row, tags: list[str]) -> AssetRecord:
+        metadata = self._deserialize_metadata(row["metadata"])
+        created_at = datetime.fromisoformat(row["created_at"])
+        updated_at = datetime.fromisoformat(row["updated_at"])
+        return AssetRecord(
+            id=row["id"],
+            path=str(row["path"]),
+            label=str(row["label"]),
+            metadata=metadata,
+            tags=list(tags),
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+    def _deserialize_metadata(self, payload: str | None) -> dict[str, Any]:
+        if not payload:
+            return {}
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(data, dict):
+            return dict(data)
+        return {}
+
+    def _replace_tags(self, connection: Connection, asset_id: int, tags: list[str]) -> None:
+        connection.execute(
+            "DELETE FROM asset_tags WHERE asset_id = ?",
+            (asset_id,),
+        )
+        if not tags:
+            return
+        connection.executemany(
+            "INSERT INTO asset_tags(asset_id, tag) VALUES(?, ?)",
+            [(asset_id, tag) for tag in tags],
+        )

--- a/src/three_dfs/storage/service.py
+++ b/src/three_dfs/storage/service.py
@@ -1,0 +1,210 @@
+"""High level service facade for interacting with the asset repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Iterator, Mapping
+
+from .repository import AssetRecord, AssetRepository
+
+__all__ = ["AssetSeed", "AssetService"]
+
+
+@dataclass(frozen=True, slots=True)
+class AssetSeed:
+    """Describe an asset used when bootstrapping demo data."""
+
+    path: str
+    label: str
+    metadata: Mapping[str, Any] | None = None
+    tags: tuple[str, ...] = ()
+
+
+DEFAULT_ASSET_SEEDS: tuple[AssetSeed, ...] = (
+    AssetSeed(
+        path="docs/overview.md",
+        label="Project overview",
+        metadata={"description": "High level summary of the 3dfs project."},
+        tags=("docs", "overview"),
+    ),
+    AssetSeed(
+        path="assets/textures/terrain.png",
+        label="Terrain texture",
+        metadata={"description": "Ground texture used by the default scene."},
+        tags=("texture", "environment"),
+    ),
+    AssetSeed(
+        path="assets/models/ship.fbx",
+        label="Spaceship model",
+        metadata={"description": "Primary spacecraft mesh exported from Blender."},
+        tags=("model", "vehicle"),
+    ),
+    AssetSeed(
+        path="scripts/build.py",
+        label="Build automation script",
+        metadata={"description": "Helper script for packaging distributables."},
+        tags=("automation", "python"),
+    ),
+    AssetSeed(
+        path="notes/ideas.txt",
+        label="Concept notes",
+        metadata={"description": "Scratch pad for brainstorming new features."},
+        tags=("notes", "ideas"),
+    ),
+)
+
+
+class AssetService:
+    """Coordinate high level operations on :class:`AssetRecord` objects."""
+
+    def __init__(self, repository: AssetRepository | None = None) -> None:
+        self._repository = repository or AssetRepository()
+
+    # ------------------------------------------------------------------
+    # Basic accessors
+    # ------------------------------------------------------------------
+    @property
+    def repository(self) -> AssetRepository:
+        """Expose the underlying repository instance."""
+
+        return self._repository
+
+    def list_assets(self) -> list[AssetRecord]:
+        """Return all persisted assets."""
+
+        return self._repository.list_assets()
+
+    def get_asset_by_path(self, path: str) -> AssetRecord | None:
+        """Fetch an asset by its unique path."""
+
+        return self._repository.get_asset_by_path(path)
+
+    def create_asset(
+        self,
+        path: str,
+        *,
+        label: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        tags: Iterable[str] | None = None,
+    ) -> AssetRecord:
+        """Persist a new asset record."""
+
+        return self._repository.create_asset(
+            path,
+            label=label,
+            metadata=metadata,
+            tags=tags,
+        )
+
+    def ensure_asset(
+        self,
+        path: str,
+        *,
+        label: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AssetRecord:
+        """Return the stored asset for *path* creating one if necessary."""
+
+        return self._repository.ensure_asset(path, label=label, metadata=metadata)
+
+    def delete_asset(self, asset_id: int) -> bool:
+        """Remove an asset by its identifier."""
+
+        return self._repository.delete_asset(asset_id)
+
+    def delete_asset_by_path(self, path: str) -> bool:
+        """Remove an asset identified by *path*."""
+
+        return self._repository.delete_asset_by_path(path)
+
+    def update_asset(
+        self,
+        asset_id: int,
+        *,
+        path: str | None = None,
+        label: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AssetRecord:
+        """Update attributes on an existing asset."""
+
+        kwargs: dict[str, Any] = {}
+        if metadata is not None:
+            kwargs["metadata"] = metadata
+        return self._repository.update_asset(
+            asset_id,
+            path=path,
+            label=label,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Tag operations
+    # ------------------------------------------------------------------
+    def tags_for_path(self, path: str) -> list[str]:
+        """Return the tag list for *path*."""
+
+        return self._repository.tags_for_path(path)
+
+    def set_tags(self, path: str, tags: Iterable[str]) -> list[str]:
+        """Replace the tag list for *path*."""
+
+        asset = self.ensure_asset(path, label=path)
+        return self._repository.set_tags(asset.id, tags)
+
+    def add_tag(self, path: str, tag: str) -> str | None:
+        """Assign *tag* to the asset identified by *path*."""
+
+        asset = self.ensure_asset(path, label=path)
+        return self._repository.add_tag(asset.id, tag)
+
+    def remove_tag(self, path: str, tag: str) -> bool:
+        """Remove *tag* from the asset identified by *path*."""
+
+        asset = self.get_asset_by_path(path)
+        if asset is None:
+            return False
+        return self._repository.remove_tag(asset.id, tag)
+
+    def rename_tag(self, path: str, old_tag: str, new_tag: str) -> str | None:
+        """Rename *old_tag* to *new_tag* for the asset identified by *path*."""
+
+        asset = self.get_asset_by_path(path)
+        if asset is None:
+            return None
+        return self._repository.rename_tag(asset.id, old_tag, new_tag)
+
+    def search_tags(self, query: str) -> dict[str, list[str]]:
+        """Return a mapping of paths to tags matching *query*."""
+
+        return self._repository.search_tags(query)
+
+    def all_tags(self) -> list[str]:
+        """Return the universe of known tag names."""
+
+        return self._repository.all_tags()
+
+    def iter_tagged_assets(self) -> Iterator[tuple[str, list[str]]]:
+        """Yield ``(path, tags)`` pairs for assets that have tags."""
+
+        return self._repository.iter_tagged_assets()
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+    def bootstrap_demo_data(self) -> list[AssetRecord]:
+        """Populate the repository with default entries when empty."""
+
+        existing = self.list_assets()
+        if existing:
+            return existing
+
+        for seed in DEFAULT_ASSET_SEEDS:
+            metadata = dict(seed.metadata) if seed.metadata is not None else None
+            self.create_asset(
+                seed.path,
+                label=seed.label,
+                metadata=metadata,
+                tags=seed.tags,
+            )
+
+        return self.list_assets()

--- a/tests/storage/test_repository.py
+++ b/tests/storage/test_repository.py
@@ -1,0 +1,78 @@
+"""Tests covering the SQLite-backed asset repository and service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from three_dfs.storage import AssetRepository, AssetService, SQLiteStorage
+
+
+def test_sqlite_storage_initializes_schema(tmp_path: Path) -> None:
+    db_path = tmp_path / "assets.sqlite3"
+    storage = SQLiteStorage(db_path)
+
+    assert db_path.exists()
+
+    with storage.connect() as connection:
+        tables = {
+            row["name"]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+
+    assert {"assets", "asset_tags"}.issubset(tables)
+
+
+def test_asset_repository_persists_records(tmp_path: Path) -> None:
+    storage = SQLiteStorage(tmp_path / "assets.sqlite3")
+    repository = AssetRepository(storage)
+
+    created = repository.create_asset(
+        "assets/models/ship.fbx",
+        label="Spaceship",
+        metadata={"description": "Spacecraft for testing"},
+        tags=["vehicle", "model"],
+    )
+
+    assert created.id > 0
+    assert created.tags == ["model", "vehicle"]
+
+    fetched = repository.get_asset_by_path("assets/models/ship.fbx")
+    assert fetched is not None
+    assert fetched.metadata["description"] == "Spacecraft for testing"
+
+    repository.add_tag(created.id, "Featured")
+    repository.remove_tag(created.id, "model")
+
+    refreshed = repository.get_asset(created.id)
+    assert refreshed is not None
+    assert refreshed.tags == ["Featured", "vehicle"]
+
+    repository.set_tags(created.id, ["alpha", "beta"])
+    updated = repository.get_asset(created.id)
+    assert updated is not None
+    assert updated.tags == ["alpha", "beta"]
+
+    listing = repository.list_assets()
+    assert [asset.path for asset in listing] == ["assets/models/ship.fbx"]
+
+    search_results = repository.search_tags("alp")
+    assert search_results == {"assets/models/ship.fbx": ["alpha"]}
+
+
+def test_asset_service_bootstrap_demo_data(tmp_path: Path) -> None:
+    storage = SQLiteStorage(tmp_path / "assets.sqlite3")
+    repository = AssetRepository(storage)
+    service = AssetService(repository)
+
+    assets = service.bootstrap_demo_data()
+    assert len(assets) >= 1
+
+    # Bootstrapping again should not duplicate entries.
+    second_run = service.bootstrap_demo_data()
+    assert [asset.path for asset in assets] == [asset.path for asset in second_run]
+
+    # At least one asset should expose tags via the service.
+    tagged = {path: tags for path, tags in service.iter_tagged_assets()}
+    assert tagged

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -8,7 +8,7 @@ from three_dfs.data.tags import TagStore
 
 
 def test_tag_store_add_remove_rename(tmp_path: Path) -> None:
-    store_path = tmp_path / "tags.json"
+    store_path = tmp_path / "assets.sqlite3"
     store = TagStore(store_path)
 
     assert store.tags_for("item-1") == []
@@ -32,14 +32,14 @@ def test_tag_store_add_remove_rename(tmp_path: Path) -> None:
 
 
 def test_tag_store_persistence_roundtrip(tmp_path: Path) -> None:
-    store_path = tmp_path / "tags.json"
+    store_path = tmp_path / "assets.sqlite3"
     store = TagStore(store_path)
 
     store.add_tag("foo", "Bar")
     store.add_tag("foo", "Baz")
     store.add_tag("qux", "Bar")
 
-    # A new instance pointing to the same file should read the state back.
+    # A new instance pointing to the same database should read the state back.
     reloaded = TagStore(store_path)
     assert reloaded.tags_for("foo") == ["Bar", "Baz"]
     assert reloaded.search("bar") == {"foo": ["Bar"], "qux": ["Bar"]}


### PR DESCRIPTION
## Summary
- add a new `three_dfs.storage` package with SQLite helpers, repository objects, and an asset service
- refactor the Qt bootstrap and tag store to load asset data and tags from the shared storage service
- exercise the storage logic with new unit tests and update existing tag store tests for the SQLite backend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb223260748325bc48912fc2f04010