### PR TITLE
Add importer for STL/OBJ/STEP assets

### DIFF
--- a/src/three_dfs/importer.py
+++ b/src/three_dfs/importer.py
@@ -1,0 +1,135 @@
+"""Utilities for importing external 3D assets into managed storage."""
+
+from __future__ import annotations
+
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from .storage import AssetService
+
+if TYPE_CHECKING:
+    from .storage import AssetRecord
+
+__all__ = [
+    "SUPPORTED_EXTENSIONS",
+    "AssetImportError",
+    "UnsupportedAssetTypeError",
+    "import_asset",
+]
+
+SUPPORTED_EXTENSIONS: Final[frozenset[str]] = frozenset(
+    {
+        ".stl",
+        ".obj",
+        ".step",
+        ".stp",
+    }
+)
+"""Supported file extensions for imported assets."""
+
+DEFAULT_STORAGE_ROOT: Final[Path] = Path.home() / ".3dfs" / "assets" / "imports"
+"""Default directory where imported assets are stored."""
+
+
+class AssetImportError(RuntimeError):
+    """Base exception raised when an asset cannot be imported."""
+
+
+class UnsupportedAssetTypeError(AssetImportError):
+    """Raised when attempting to import an unsupported asset format."""
+
+
+def import_asset(
+    path: Path,
+    *,
+    service: AssetService | None = None,
+    storage_root: Path | None = None,
+) -> AssetRecord:
+    """Import the asset located at *path* into managed storage.
+
+    Parameters
+    ----------
+    path:
+        The filesystem path to the asset to import.
+    service:
+        Optional :class:`~three_dfs.storage.AssetService` used to register the
+        asset. A new service instance is created when omitted.
+    storage_root:
+        Directory where managed copies of imported assets are persisted. When
+        omitted the importer uses :data:`DEFAULT_STORAGE_ROOT`.
+
+    Returns
+    -------
+    AssetRecord
+        The newly registered asset record.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *path* does not exist on disk.
+    AssetImportError
+        If *path* is not a file or has an unsupported extension.
+    """
+
+    source = Path(path).expanduser()
+    try:
+        source = source.resolve(strict=True)
+    except FileNotFoundError as exc:  # pragma: no cover - value re-raised unchanged
+        raise FileNotFoundError(f"Asset {path!s} does not exist") from exc
+
+    if not source.is_file():
+        raise AssetImportError(f"Asset {source!s} is not a file")
+
+    extension = source.suffix.lower()
+    if extension not in SUPPORTED_EXTENSIONS:
+        raise UnsupportedAssetTypeError(
+            f"Unsupported asset format '{extension or 'unknown'}'"
+        )
+
+    managed_root = Path(storage_root or DEFAULT_STORAGE_ROOT).expanduser()
+    managed_root.mkdir(parents=True, exist_ok=True)
+    destination = _allocate_destination(managed_root, source.name)
+
+    shutil.copy2(source, destination)
+    imported_at = datetime.now(UTC).isoformat()
+    metadata = {
+        "original_path": str(source),
+        "managed_path": str(destination),
+        "extension": extension.lstrip(".").upper(),
+        "size": destination.stat().st_size,
+        "imported_at": imported_at,
+    }
+
+    asset_service = service or AssetService()
+    try:
+        record = asset_service.create_asset(
+            destination.as_posix(),
+            label=source.stem,
+            metadata=metadata,
+        )
+    except Exception:
+        destination.unlink(missing_ok=True)
+        raise
+
+    return record
+
+
+def _allocate_destination(storage_root: Path, filename: str) -> Path:
+    """Return a non-conflicting destination for *filename* within *storage_root*."""
+
+    candidate = storage_root / filename
+    if not candidate.exists():
+        return candidate
+
+    original = Path(filename)
+    stem = original.stem
+    suffix = original.suffix
+    counter = 1
+
+    while True:
+        candidate = storage_root / f"{stem}_{counter}{suffix}"
+        if not candidate.exists():
+            return candidate
+        counter += 1

--- a/tests/fixtures/sample_mesh.stl
+++ b/tests/fixtures/sample_mesh.stl
@@ -1,0 +1,9 @@
+solid sample_mesh
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 1 0 0
+      vertex 0 1 0
+    endloop
+  endfacet
+endsolid sample_mesh

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,127 @@
+"""Tests covering the importer responsible for handling new asset files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from three_dfs.importer import (
+    AssetImportError,
+    UnsupportedAssetTypeError,
+    import_asset,
+)
+from three_dfs.storage import AssetRepository, AssetService, SQLiteStorage
+
+
+@pytest.fixture()
+def asset_service(tmp_path: Path) -> AssetService:
+    """Provide an asset service backed by a temporary SQLite database."""
+
+    storage = SQLiteStorage(tmp_path / "assets.sqlite3")
+    repository = AssetRepository(storage)
+    return AssetService(repository)
+
+
+@pytest.fixture()
+def managed_storage_root(tmp_path: Path) -> Path:
+    """Return the root directory used for managed asset copies during tests."""
+
+    return tmp_path / "managed_assets"
+
+
+@pytest.fixture()
+def sample_stl_path() -> Path:
+    """Return the path to the bundled sample STL asset."""
+
+    return Path(__file__).parent / "fixtures" / "sample_mesh.stl"
+
+
+def test_importer_registers_supported_asset(
+    asset_service: AssetService,
+    managed_storage_root: Path,
+    sample_stl_path: Path,
+) -> None:
+    """Importer should copy files into managed storage and register metadata."""
+
+    record = import_asset(
+        sample_stl_path,
+        service=asset_service,
+        storage_root=managed_storage_root,
+    )
+
+    assert record.id > 0
+    assert Path(record.path).exists()
+
+    managed_path = Path(record.metadata["managed_path"])
+    assert managed_path.exists()
+    assert managed_path.parent == managed_storage_root
+    assert managed_path.read_text().strip().startswith("solid")
+
+    fetched = asset_service.get_asset_by_path(record.path)
+    assert fetched is not None
+    assert fetched.path == record.path
+    assert fetched.metadata["original_path"].endswith("sample_mesh.stl")
+
+    stored_files = list(managed_storage_root.iterdir())
+    assert stored_files == [managed_path]
+
+
+def test_importer_rejects_unsupported_extension(
+    asset_service: AssetService,
+    managed_storage_root: Path,
+    tmp_path: Path,
+) -> None:
+    """Importer should raise a helpful error when encountering bad formats."""
+
+    unsupported = tmp_path / "model.fbx"
+    unsupported.write_text("dummy contents", encoding="utf-8")
+
+    with pytest.raises(UnsupportedAssetTypeError):
+        import_asset(
+            unsupported,
+            service=asset_service,
+            storage_root=managed_storage_root,
+        )
+
+    assert not managed_storage_root.exists()
+
+
+def test_importer_rejects_missing_files(
+    asset_service: AssetService,
+    managed_storage_root: Path,
+    tmp_path: Path,
+) -> None:
+    """Importer should surface an informative error for missing inputs."""
+
+    missing = tmp_path / "missing.step"
+
+    with pytest.raises(FileNotFoundError):
+        import_asset(
+            missing,
+            service=asset_service,
+            storage_root=managed_storage_root,
+        )
+
+    # The importer should not create storage directories when it fails early.
+    assert not managed_storage_root.exists()
+
+
+def test_importer_rejects_directories(
+    asset_service: AssetService,
+    managed_storage_root: Path,
+    tmp_path: Path,
+) -> None:
+    """Directories are not valid input sources for the importer."""
+
+    source_dir = tmp_path / "source_dir"
+    source_dir.mkdir()
+
+    with pytest.raises(AssetImportError):
+        import_asset(
+            source_dir,
+            service=asset_service,
+            storage_root=managed_storage_root,
+        )
+
+    assert not managed_storage_root.exists()


### PR DESCRIPTION
## Summary
- add an importer module that validates STL/OBJ/STEP inputs, copies them into managed storage, and registers them with the asset service
- include a sample STL fixture and unit tests covering successful imports and error cases for unsupported formats and invalid sources

## Testing
- PYTHONPATH=src pytest
- ruff check src/three_dfs/importer.py tests/test_importer.py
- black --check src/three_dfs/importer.py tests/test_importer.py

------
https://chatgpt.com/codex/tasks/task_e_68cb5e08b36883258a7814cee61b209d