### PR TITLE
Normalize asset tags and enhance tagging UI

### DIFF
--- a/src/three_dfs/db/models.py
+++ b/src/three_dfs/db/models.py
@@ -140,7 +140,7 @@ SessionLocal = create_session_factory()
 
 
 asset_tag_table = Table(
-    "asset_tags",
+    "asset_tag_links",
     metadata,
     Column("asset_id", ForeignKey("assets.id", ondelete="CASCADE"), primary_key=True),
     Column("tag_id", ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True),


### PR DESCRIPTION
## Summary
- add normalized `tags` and `asset_tag_links` tables with migration support and update ORM metadata
- refactor repository tag operations to use the normalized schema and prune unused tag entries
- surface existing tag suggestions in the sidebar UI and expand repository tests for tag persistence and migration

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc53a87e8c8325b78fc7b8a336d855