### PR TITLE
Add importer plugin system for remote assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,30 @@ standards documentation.
 
 Additional design documents, architectural notes, and implementation
 code will be layered onto this foundation in subsequent milestones.
+
+## Import plugins
+
+The importer can fetch remote assets through pluggable backends. Plugins
+implement the :class:`three_dfs.import_plugins.ImportPlugin` protocol and
+register themselves either programmatically via
+``three_dfs.import_plugins.register_plugin`` or by exposing an entry point in
+the ``three_dfs.import_plugins`` group. When the importer receives an
+identifier that does not resolve to a local file it asks the registered
+plugins if they can handle the source and delegates the download to the
+matching implementation. The returned metadata is merged with the built-in
+fields so remote associations (for example ``remote_source``) are preserved in
+the resulting asset record.
+
+To jump-start development of a new integration you can use the scaffold
+utility:
+
+```python
+from three_dfs.import_plugins import scaffold_plugin
+
+module_path = scaffold_plugin("Sketchfab", "./plugins")
+print(f"Created plugin skeleton at {module_path}")
+```
+
+The generated module contains TODO markers for authentication, scraping, and
+metadata mapping. Fill in those hooks, ensure the plugin returns the fetched
+asset in a supported format, and register it with the global registry.

--- a/src/three_dfs/data/tags.py
+++ b/src/three_dfs/data/tags.py
@@ -20,7 +20,9 @@ class TagStore:
         service: AssetService | None = None,
     ) -> None:
         if path is not None and service is not None:
-            raise ValueError("Provide either a database path or an AssetService, not both.")
+            raise ValueError(
+                "Provide either a database path or an AssetService, not both."
+            )
 
         if service is None:
             storage = SQLiteStorage(path)

--- a/src/three_dfs/db/models.py
+++ b/src/three_dfs/db/models.py
@@ -20,6 +20,7 @@ SQLite-backed engine, constructing sessions, and accessing the shared
 ``get_engine``/``create_session_factory`` to bootstrap the database without
 having to duplicate configuration boilerplate.
 """
+
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/src/three_dfs/import_plugins/__init__.py
+++ b/src/three_dfs/import_plugins/__init__.py
@@ -1,0 +1,215 @@
+"""Plugin interface and utilities for the asset importer."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import MutableMapping
+from importlib.metadata import EntryPoint, entry_points
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+Metadata = MutableMapping[str, Any]
+"""Mutable mapping used for metadata returned by import plugins."""
+
+ENTRYPOINT_GROUP = "three_dfs.import_plugins"
+"""Entry-point group used to auto-discover importer plugins."""
+
+
+@runtime_checkable
+class ImportPlugin(Protocol):
+    """Protocol describing the expected importer plugin behaviour."""
+
+    def can_handle(self, source: str) -> bool:
+        """Return ``True`` when the plugin is able to fetch *source*."""
+
+    def fetch(self, source: str, destination: Path) -> Metadata:
+        """Download the asset identified by *source* into *destination*."""
+
+
+_registry: list[ImportPlugin] = []
+_entry_points_loaded = False
+
+__all__ = [
+    "ENTRYPOINT_GROUP",
+    "ImportPlugin",
+    "Metadata",
+    "iter_plugins",
+    "load_entrypoint_plugins",
+    "register_plugin",
+    "scaffold_plugin",
+    "unregister_plugin",
+]
+
+
+def register_plugin(plugin: ImportPlugin) -> ImportPlugin:
+    """Register *plugin* with the importer registry."""
+
+    if plugin not in _registry:
+        _registry.append(plugin)
+    return plugin
+
+
+def unregister_plugin(plugin: ImportPlugin) -> None:
+    """Remove *plugin* from the importer registry when present."""
+
+    try:
+        _registry.remove(plugin)
+    except ValueError:  # pragma: no cover - defensive guard
+        pass
+
+
+def iter_plugins() -> tuple[ImportPlugin, ...]:
+    """Return the registered plugins, loading entry points on first access."""
+
+    _ensure_entry_points_loaded()
+    return tuple(_registry)
+
+
+def load_entrypoint_plugins(group: str = ENTRYPOINT_GROUP) -> tuple[ImportPlugin, ...]:
+    """Discover and register plugins exposed through *group* entry points."""
+
+    global _entry_points_loaded
+    discovered = tuple(_discover_entrypoint_plugins(group))
+    for plugin in discovered:
+        register_plugin(plugin)
+    if group == ENTRYPOINT_GROUP:
+        _entry_points_loaded = True
+    return discovered
+
+
+def scaffold_plugin(repo_name: str, target_dir: str | Path) -> Path:
+    """Create a skeleton plugin for *repo_name* inside *target_dir*."""
+
+    target_path = Path(target_dir).expanduser()
+    target_path.mkdir(parents=True, exist_ok=True)
+
+    module_stub = _normalize_module_name(repo_name)
+    class_name = _build_class_name(repo_name)
+
+    filename = f"{module_stub}_plugin.py"
+    destination = target_path / filename
+    if destination.exists():
+        raise FileExistsError(f"Plugin module {destination} already exists")
+
+    template = f'''"""Import plugin scaffold for {repo_name}."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from three_dfs.import_plugins import ImportPlugin, Metadata, register_plugin
+
+
+class {class_name}(ImportPlugin):
+    """Interact with {repo_name} to import 3D assets."""
+
+    def can_handle(self, source: str) -> bool:
+        """Return ``True`` when *source* belongs to {repo_name}."""
+        # TODO: Refine detection logic for {repo_name} identifiers.
+        return source.startswith("{module_stub}://")
+
+    def fetch(self, source: str, destination: Path) -> Metadata:
+        """Download the asset identified by *source* into *destination*."""
+        # TODO: Handle authentication for {repo_name} APIs.
+        # TODO: Scrape or download the asset payload into *destination*.
+        # TODO: Map remote metadata fields into the returned dictionary.
+        raise NotImplementedError(
+            "Fetching assets from {repo_name} is not implemented yet."
+        )
+
+
+register_plugin({class_name}())
+'''
+
+    destination.write_text(template, encoding="utf-8")
+    return destination
+
+
+def _ensure_entry_points_loaded() -> None:
+    """Load entry-point plugins once on demand."""
+
+    global _entry_points_loaded
+    if _entry_points_loaded:
+        return
+    load_entrypoint_plugins()
+
+
+def _discover_entrypoint_plugins(group: str) -> list[ImportPlugin]:
+    """Return plugins discovered for *group* entry points."""
+
+    entries = _select_entry_points(group)
+    plugins: list[ImportPlugin] = []
+
+    for entry in entries:
+        try:
+            loaded = entry.load()
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Failed to load import plugin entry point %s", entry.name)
+            continue
+
+        plugin = _coerce_plugin(loaded)
+        if plugin is None:
+            logger.warning(
+                "Entry point %s from %s did not provide an ImportPlugin",
+                entry.name,
+                entry.module,
+            )
+            continue
+
+        plugins.append(plugin)
+
+    return plugins
+
+
+def _select_entry_points(group: str) -> tuple[EntryPoint, ...]:
+    """Return entry points for *group* with compatibility fallbacks."""
+
+    discovered = entry_points()
+    if isinstance(discovered, dict):  # pragma: no cover - legacy interface
+        entries = discovered.get(group, ())
+    else:
+        entries = discovered.select(group=group)
+    return tuple(entries)
+
+
+def _coerce_plugin(candidate: Any) -> ImportPlugin | None:
+    """Convert entry-point *candidate* to an :class:`ImportPlugin` instance."""
+
+    if isinstance(candidate, ImportPlugin):
+        return candidate
+
+    if callable(candidate):
+        try:
+            plugin = candidate()
+        except TypeError:
+            logger.exception(
+                "Import plugin factory %r could not be instantiated", candidate
+            )
+            return None
+
+        if isinstance(plugin, ImportPlugin):
+            return plugin
+
+    return None
+
+
+def _normalize_module_name(name: str) -> str:
+    """Return a filesystem-friendly module stub for *name*."""
+
+    module = re.sub(r"[^0-9a-zA-Z]+", "_", name).strip("_").lower()
+    return module or "import_plugin"
+
+
+def _build_class_name(name: str) -> str:
+    """Return a CamelCase class name suitable for *name*."""
+
+    parts = re.split(r"[^0-9a-zA-Z]+", name)
+    class_base = "".join(part.capitalize() for part in parts if part)
+    if not class_base:
+        class_base = "External"
+    if not class_base.endswith("Plugin"):
+        class_base = f"{class_base}ImportPlugin"
+    return class_base

--- a/src/three_dfs/storage/database.py
+++ b/src/three_dfs/storage/database.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import Optional
 
 DEFAULT_DB_FILENAME = "assets.sqlite3"
 DEFAULT_DB_PATH = Path.home() / ".3dfs" / DEFAULT_DB_FILENAME
@@ -47,7 +46,7 @@ class SQLiteStorage:
 
         if str(raw_path) == ":memory:":
             self._database = ":memory:"
-            self._path: Optional[Path] = None
+            self._path: Path | None = None
         else:
             actual_path = Path(raw_path).expanduser()
             actual_path.parent.mkdir(parents=True, exist_ok=True)
@@ -60,7 +59,7 @@ class SQLiteStorage:
     # Public API
     # ------------------------------------------------------------------
     @property
-    def path(self) -> Optional[Path]:
+    def path(self) -> Path | None:
         """Return the filesystem location for the database if persisted."""
 
         return self._path
@@ -108,9 +107,7 @@ class SQLiteStorage:
             # The database already uses the new schema.
             return
 
-        rows = connection.execute(
-            "SELECT asset_id, tag FROM asset_tags"
-        ).fetchall()
+        rows = connection.execute("SELECT asset_id, tag FROM asset_tags").fetchall()
 
         def ensure_tag_id(tag_name: str) -> int:
             existing = connection.execute(

--- a/src/three_dfs/storage/repository.py
+++ b/src/three_dfs/storage/repository.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from sqlite3 import Connection
-from typing import Any, Iterable, Iterator, Mapping
+from typing import Any
 
 from .database import SQLiteStorage
 
@@ -455,10 +456,7 @@ class AssetRepository:
             return []
         asset_ids = [row["id"] for row in rows]
         tags_map = self._tags_for_asset_ids(connection, asset_ids)
-        return [
-            self._row_to_record(row, tags_map.get(row["id"], []))
-            for row in rows
-        ]
+        return [self._row_to_record(row, tags_map.get(row["id"], [])) for row in rows]
 
     def _tags_for_asset_ids(
         self, connection: Connection, asset_ids: list[int]
@@ -506,7 +504,9 @@ class AssetRepository:
             return dict(data)
         return {}
 
-    def _replace_tags(self, connection: Connection, asset_id: int, tags: list[str]) -> None:
+    def _replace_tags(
+        self, connection: Connection, asset_id: int, tags: list[str]
+    ) -> None:
         connection.execute(
             "DELETE FROM asset_tag_links WHERE asset_id = ?",
             (asset_id,),

--- a/src/three_dfs/storage/service.py
+++ b/src/three_dfs/storage/service.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
-from typing import Any, Iterable, Iterator, Mapping
+from typing import Any
 
 from .repository import AssetRecord, AssetRepository
 

--- a/tests/import_plugins/test_plugins.py
+++ b/tests/import_plugins/test_plugins.py
@@ -1,0 +1,107 @@
+"""Tests covering the import plugin infrastructure."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from three_dfs.import_plugins import (
+    iter_plugins,
+    register_plugin,
+    scaffold_plugin,
+    unregister_plugin,
+)
+from three_dfs.importer import import_asset
+from three_dfs.storage import AssetRepository, AssetService, SQLiteStorage
+
+
+class DummyPlugin:
+    """Simple plugin used to exercise the registry and importer."""
+
+    def __init__(self, fixture: Path) -> None:
+        self.fixture = fixture
+
+    def can_handle(self, source: str) -> bool:
+        return source.startswith("dummy://")
+
+    def fetch(self, source: str, destination: Path) -> dict[str, object]:
+        shutil.copy2(self.fixture, destination)
+        return {"remote_source": source, "dummy": True}
+
+
+@pytest.fixture()
+def sample_stl_path() -> Path:
+    """Return the path to the bundled STL sample."""
+
+    return Path(__file__).resolve().parent.parent / "fixtures" / "sample_mesh.stl"
+
+
+@pytest.fixture()
+def asset_service(tmp_path: Path) -> AssetService:
+    """Provide an asset service backed by a temporary database."""
+
+    storage = SQLiteStorage(tmp_path / "assets.sqlite3")
+    repository = AssetRepository(storage)
+    return AssetService(repository)
+
+
+@pytest.fixture()
+def managed_storage_root(tmp_path: Path) -> Path:
+    """Return the directory used for managed copies during tests."""
+
+    return tmp_path / "managed_assets"
+
+
+@pytest.fixture()
+def dummy_plugin(sample_stl_path: Path) -> DummyPlugin:
+    """Register the dummy plugin for the duration of a test."""
+
+    plugin = DummyPlugin(sample_stl_path)
+    register_plugin(plugin)
+    try:
+        yield plugin
+    finally:
+        unregister_plugin(plugin)
+
+
+def test_registry_detects_registered_plugin(dummy_plugin: DummyPlugin) -> None:
+    """Plugins registered at runtime should be visible via the iterator."""
+
+    assert dummy_plugin in iter_plugins()
+
+
+def test_importer_uses_remote_plugin(
+    dummy_plugin: DummyPlugin,
+    asset_service: AssetService,
+    managed_storage_root: Path,
+) -> None:
+    """Importer should leverage plugins for remote sources and keep metadata."""
+
+    remote_identifier = "dummy://assets/sample_mesh.stl"
+    record = import_asset(
+        remote_identifier,
+        service=asset_service,
+        storage_root=managed_storage_root,
+    )
+
+    metadata = record.metadata
+    assert metadata["remote_source"] == remote_identifier
+    assert metadata["source_type"] == "remote"
+    assert metadata["dummy"] is True
+    assert Path(metadata["managed_path"]).exists()
+    assert record.path == metadata["managed_path"]
+
+
+def test_scaffold_plugin_emits_template(tmp_path: Path) -> None:
+    """The scaffold helper should generate a plugin stub with TODO hooks."""
+
+    module_path = scaffold_plugin("Example Repo", tmp_path)
+    contents = module_path.read_text(encoding="utf-8")
+
+    assert module_path.exists()
+    assert "class ExampleRepoImportPlugin" in contents
+    assert "TODO: Handle authentication" in contents
+    assert "TODO: Scrape or download" in contents
+    assert "TODO: Map remote metadata" in contents


### PR DESCRIPTION
## Summary
- add the `three_dfs.import_plugins` package with a registry, entry-point discovery, and a scaffold helper for new integrations
- extend the importer to delegate remote identifiers to registered plugins and merge their metadata
- document plugin usage and cover the plugin workflow with unit tests while updating supporting modules for lint compliance

## Testing
- ruff check src tests
- black --check src tests
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc67c0a7388325a98d1796923c30ae