### PR TITLE
Add customizations schema tables to SQLite storage

### DIFF
--- a/src/three_dfs/storage/database.py
+++ b/src/three_dfs/storage/database.py
@@ -29,9 +29,31 @@ CREATE TABLE IF NOT EXISTS asset_tag_links (
     PRIMARY KEY (asset_id, tag_id)
 );
 
+CREATE TABLE IF NOT EXISTS customizations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    base_asset_id INTEGER NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+    parameters TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS asset_relationships (
+    customization_id INTEGER NOT NULL REFERENCES customizations(id) ON DELETE CASCADE,
+    generated_asset_id INTEGER NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+    relationship_type TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (customization_id, generated_asset_id, relationship_type)
+);
+
 CREATE INDEX IF NOT EXISTS idx_tags_name ON tags(name);
 CREATE INDEX IF NOT EXISTS idx_asset_tag_links_tag_id ON asset_tag_links(tag_id);
 CREATE INDEX IF NOT EXISTS idx_asset_tag_links_asset_id ON asset_tag_links(asset_id);
+CREATE INDEX IF NOT EXISTS idx_customizations_base_asset_id ON customizations(base_asset_id);
+CREATE INDEX IF NOT EXISTS idx_asset_relationships_customization_id
+    ON asset_relationships(customization_id);
+CREATE INDEX IF NOT EXISTS idx_asset_relationships_generated_asset_id
+    ON asset_relationships(generated_asset_id);
 """
 
 

--- a/tests/storage/test_repository.py
+++ b/tests/storage/test_repository.py
@@ -22,9 +22,39 @@ def test_sqlite_storage_initializes_schema(tmp_path: Path) -> None:
                 "SELECT name FROM sqlite_master WHERE type='table'"
             ).fetchall()
         }
+        columns = {
+            table: {
+                row["name"]: row
+                for row in connection.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+            for table in ("customizations", "asset_relationships")
+        }
 
-    assert {"assets", "tags", "asset_tag_links"}.issubset(tables)
+    assert {
+        "assets",
+        "tags",
+        "asset_tag_links",
+        "customizations",
+        "asset_relationships",
+    }.issubset(tables)
     assert "asset_tags" not in tables
+
+    assert set(columns["customizations"]) == {
+        "id",
+        "base_asset_id",
+        "parameters",
+        "created_at",
+        "updated_at",
+    }
+    assert columns["customizations"]["parameters"]["dflt_value"] == "'{}'"
+
+    assert set(columns["asset_relationships"]) == {
+        "customization_id",
+        "generated_asset_id",
+        "relationship_type",
+        "created_at",
+        "updated_at",
+    }
 
 
 def test_asset_repository_persists_records(tmp_path: Path) -> None:
@@ -120,7 +150,13 @@ def test_sqlite_storage_migrates_legacy_tag_schema(tmp_path: Path) -> None:
             ).fetchall()
         }
 
-    assert {"assets", "tags", "asset_tag_links"}.issubset(tables)
+    assert {
+        "assets",
+        "tags",
+        "asset_tag_links",
+        "customizations",
+        "asset_relationships",
+    }.issubset(tables)
     assert "asset_tags" not in tables
 
 


### PR DESCRIPTION
## Summary
- extend the SQLite schema with customizations and asset_relationships tables to capture customization metadata and derived assets
- add supporting indexes for the new tables to keep lookups efficient
- update repository tests to assert the new tables and columns exist when initializing or migrating databases

## Testing
- pytest tests/storage/test_repository.py

------
https://chatgpt.com/codex/tasks/task_e_68cd88ced1b88325ad4e31e37a0331c1