### PR TITLE
Add customization status tracking and UI indicators

### DIFF
--- a/src/three_dfs/customizer/__init__.py
+++ b/src/three_dfs/customizer/__init__.py
@@ -12,8 +12,10 @@ __all__ = [
     "GeneratedArtifact",
     "CustomizerSession",
     "CustomizerBackend",
+    "CustomizationStatus",
     "ArtifactResult",
     "PipelineResult",
+    "evaluate_customization_status",
     "execute_customization",
 ]
 
@@ -201,7 +203,8 @@ class CustomizerBackend(Protocol):
         """Return a :class:`CustomizerSession` describing the build plan."""
 
 
-from .pipeline import ArtifactResult, PipelineResult, execute_customization
+from .pipeline import ArtifactResult, PipelineResult, execute_customization  # noqa: E402,I001
+from .status import CustomizationStatus, evaluate_customization_status  # noqa: E402,I001
 
 
 if TYPE_CHECKING:  # pragma: no cover - typing helpers

--- a/src/three_dfs/customizer/pipeline.py
+++ b/src/three_dfs/customizer/pipeline.py
@@ -253,6 +253,13 @@ def _build_asset_metadata(
     session_metadata: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     generated_at = datetime.now(UTC).isoformat()
+    try:
+        source_modified_at = datetime.fromtimestamp(
+            source_path.stat().st_mtime,
+            tz=UTC,
+        ).isoformat()
+    except OSError:
+        source_modified_at = None
     metadata: dict[str, Any] = {
         "source": base_asset.path,
         "source_type": "customization",
@@ -270,6 +277,8 @@ def _build_asset_metadata(
         "backend": backend_identifier,
         "base_asset_id": base_asset.id,
         "base_asset_path": base_asset.path,
+        "base_asset_label": base_asset.label,
+        "base_asset_updated_at": base_asset.updated_at.isoformat(),
         "relationship": artifact.relationship,
         "parameters": dict(customization.parameter_values),
         "command": list(command),
@@ -280,6 +289,9 @@ def _build_asset_metadata(
 
     if _is_preview_artifact(artifact, destination):
         customization_meta["is_preview"] = True
+
+    if source_modified_at is not None:
+        customization_meta["source_modified_at"] = source_modified_at
 
     metadata["customization"] = customization_meta
     return metadata

--- a/src/three_dfs/customizer/status.py
+++ b/src/three_dfs/customizer/status.py
@@ -1,0 +1,103 @@
+"""Helpers for evaluating relationships between customized assets and sources."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+__all__ = ["CustomizationStatus", "evaluate_customization_status"]
+
+
+@dataclass(slots=True)
+class CustomizationStatus:
+    """Represent the linkage between a customization and its source."""
+
+    base_path: Path | None
+    recorded_source_mtime: datetime | None
+    current_source_mtime: datetime | None
+    is_outdated: bool
+    reason: str
+
+
+def evaluate_customization_status(
+    metadata: Mapping[str, Any],
+    *,
+    base_path: str | Path | None = None,
+) -> CustomizationStatus:
+    """Return the status of a customization relative to its source."""
+
+    resolved_base: Path | None = _resolve_base_path(metadata, base_path)
+    recorded = _parse_datetime(metadata.get("source_modified_at"))
+    current: datetime | None = None
+    reason = "Status unknown"
+    is_outdated = False
+
+    if resolved_base is None:
+        reason = "Base source path unavailable."
+    else:
+        try:
+            stat = resolved_base.stat()
+        except OSError:
+            reason = "Base source file is missing."
+            is_outdated = True
+        else:
+            current = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+            if recorded is not None:
+                if current > recorded:
+                    is_outdated = True
+                    reason = "Base source updated since customization."
+                else:
+                    reason = "In sync with base source."
+            else:
+                reason = "Recorded source timestamp unavailable."
+
+    return CustomizationStatus(resolved_base, recorded, current, is_outdated, reason)
+
+
+def _resolve_base_path(
+    metadata: Mapping[str, Any],
+    base_path: str | Path | None,
+) -> Path | None:
+    if base_path is not None:
+        return _coerce_path(base_path)
+
+    candidates = (
+        metadata.get("base_asset_path"),
+        metadata.get("source"),
+        metadata.get("base_asset"),
+    )
+    for candidate in candidates:
+        path = _coerce_path(candidate)
+        if path is not None:
+            return path
+    return None
+
+
+def _coerce_path(candidate: Any) -> Path | None:
+    if isinstance(candidate, Path):
+        return candidate.expanduser()
+    if isinstance(candidate, str):
+        stripped = candidate.strip()
+        if stripped:
+            return Path(stripped).expanduser()
+    return None
+
+
+def _parse_datetime(candidate: Any) -> datetime | None:
+    if isinstance(candidate, datetime):
+        return candidate
+    if not isinstance(candidate, str):
+        return None
+    text = candidate.strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed

--- a/tests/customizer/test_status.py
+++ b/tests/customizer/test_status.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from three_dfs.customizer.status import evaluate_customization_status
+
+
+def test_status_reports_up_to_date(tmp_path: Path) -> None:
+    source = tmp_path / "fixture.scad"
+    source.write_text("module test() {}\n", encoding="utf-8")
+
+    recorded = datetime.fromtimestamp(source.stat().st_mtime, tz=UTC)
+    metadata = {
+        "base_asset_path": str(source),
+        "source_modified_at": recorded.isoformat(),
+    }
+
+    status = evaluate_customization_status(metadata)
+
+    assert status.base_path == source
+    assert status.recorded_source_mtime == recorded
+    assert status.current_source_mtime is not None
+    assert status.is_outdated is False
+
+
+def test_status_detects_outdated_source(tmp_path: Path) -> None:
+    source = tmp_path / "fixture.scad"
+    source.write_text("module test() {}\n", encoding="utf-8")
+
+    recorded = datetime.fromtimestamp(source.stat().st_mtime, tz=UTC)
+    metadata = {
+        "base_asset_path": str(source),
+        "source_modified_at": recorded.isoformat(),
+    }
+
+    newer = recorded + timedelta(seconds=30)
+    os.utime(source, (newer.timestamp(), newer.timestamp()))
+
+    status = evaluate_customization_status(metadata)
+
+    assert status.is_outdated is True
+    assert status.current_source_mtime is not None
+    assert status.current_source_mtime > recorded
+
+
+def test_status_handles_missing_source(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.scad"
+    metadata = {
+        "base_asset_path": str(missing),
+        "source_modified_at": datetime.now(UTC).isoformat(),
+    }
+
+    status = evaluate_customization_status(metadata)
+
+    assert status.is_outdated is True
+    assert "missing" in status.reason.lower()
+
+
+def test_status_allows_base_path_override(tmp_path: Path) -> None:
+    source = tmp_path / "override.scad"
+    source.write_text("module test() {}\n", encoding="utf-8")
+
+    recorded = datetime.fromtimestamp(source.stat().st_mtime, tz=UTC)
+    metadata = {"source_modified_at": recorded.isoformat()}
+
+    status = evaluate_customization_status(metadata, base_path=source)
+
+    assert status.base_path == source
+    assert status.is_outdated is False


### PR DESCRIPTION
## Summary
- record source modification timestamps and base script details when persisting customization artifacts
- add utilities and preview panel UI to summarize customized outputs and flag stale assets
- add unit tests covering customization status evaluation and updated pipeline metadata

## Testing
- hatch run lint *(fails: repository has pre-existing lint violations; see log)*
- ruff check src/three_dfs/customizer/status.py src/three_dfs/ui/preview_pane.py tests/customizer/test_pipeline.py tests/customizer/test_status.py
- hatch run test *(fails: missing libGL.so.1 required by PySide6)*

------
https://chatgpt.com/codex/tasks/task_e_68d19f9ad0c48325b3fd96e9a37eef11