### PR TITLE
Add OpenSCAD customizer example scripts

### DIFF
--- a/docs/customizer_backends.md
+++ b/docs/customizer_backends.md
@@ -33,6 +33,11 @@ metadata, and constructs an `openscad` CLI invocation with the appropriate
 handled by the pipeline which records the parameter schema, normalised values,
 and all produced artefacts.
 
+Practical example sources live in `docs/examples/openscad/`.  They include a
+utility for embossing arbitrary STL files (`emboss_utility.scad`) and a
+demonstration corner bracket (`demo_parametric_bracket.scad`) that highlights a
+variety of parameter types available to the customizer.
+
 ## Adapting additional engines
 
 Extending the system to support another parametric modelling engine—such as a

--- a/docs/examples/openscad/README.md
+++ b/docs/examples/openscad/README.md
@@ -1,0 +1,41 @@
+# OpenSCAD customizer examples
+
+The files in this directory demonstrate how OpenSCAD sources can expose rich
+parameters for the `three_dfs` customizer backend.  Each script uses annotated
+assignments (e.g. `// [1:10]`) so the backend can extract slider ranges and
+choice lists when building parameter schemas.
+
+## `emboss_utility.scad`
+
+A utility-focused helper that embosses text or an imported 2D design onto an
+existing STL:
+
+- Toggle between a generated rounded plate or an external STL specified by the
+  `base_model` string parameter.
+- Choose between raised and recessed embossing while positioning the artwork
+  with X/Y offsets, rotation, and a configurable reference plane.
+- Independently configure lettering and imported vector artwork, including font
+  selection, mirroring, scaling, and thickness controls.
+
+Example command line usage:
+
+```bash
+openscad -o embossed_plate.stl \
+  -D 'base_model="path/to/base_plate.stl"' \
+  -D text_content="Lab 42" \
+  -D text_offset_x=20 \
+  docs/examples/openscad/emboss_utility.scad
+```
+
+## `demo_parametric_bracket.scad`
+
+A demonstration part that highlights a variety of customizer controls:
+
+- Parametric leg dimensions with adjustable fillets and curve resolution.
+- Switchable gusset styles (`solid`, `lightweight`, or `none`) with span and
+  width controls.
+- Configurable mounting holes, including safety margins and an optional second
+  position shared across both bracket legs.
+
+The generated bracket occupies the positive X/Y quadrant with the inside corner
+at the origin, making it easy to position in downstream assemblies.

--- a/docs/examples/openscad/demo_parametric_bracket.scad
+++ b/docs/examples/openscad/demo_parametric_bracket.scad
@@ -1,0 +1,125 @@
+/* [Customizer] Parametric corner bracket demonstration
+
+   A printable 90° bracket showcasing the OpenSCAD customizer workflow.  The
+   script exposes parameters for leg dimensions, mounting holes, and gusset
+   styles so users can experiment with a practical part.
+*/
+
+// -----------------------------------------------------------------------------
+// Dimension controls
+// -----------------------------------------------------------------------------
+leg_length_x = 70; // [40:1:180]
+leg_length_y = 50; // [30:1:160]
+leg_width = 24; // [12:1:60]
+leg_thickness = 5; // [2:0.5:12]
+fillet_radius = 4; // [0:0.5:18]
+curve_segments = 48; // [12:4:120]
+
+// -----------------------------------------------------------------------------
+// Gusset configuration
+// -----------------------------------------------------------------------------
+brace_style = "solid"; // ["solid", "lightweight", "none"]
+brace_length = 40; // [10:1:160]
+brace_width = 16; // [6:1:40]
+
+// -----------------------------------------------------------------------------
+// Mounting hole layout
+// -----------------------------------------------------------------------------
+hole_diameter = 5; // [3:0.5:12]
+hole_wall = 2; // [1:0.5:6]
+primary_hole_offset = 30; // [10:1:170]
+secondary_hole_offset = 55; // [15:1:180]
+use_secondary_hole = true;
+
+// -----------------------------------------------------------------------------
+// Assembly
+// -----------------------------------------------------------------------------
+module corner_bracket() {
+    difference() {
+        union() {
+            leg_body(leg_length_x, leg_width);
+            leg_body(leg_width, leg_length_y);
+            if (brace_style != "none") {
+                gusset();
+            }
+        }
+        drill_leg_holes(leg_length_x, leg_width, "x");
+        drill_leg_holes(leg_length_y, leg_width, "y");
+    }
+}
+
+module leg_body(axis_length, axis_depth) {
+    r = clamp_leg_radius(fillet_radius, axis_length, axis_depth);
+    if (r <= 0) {
+        linear_extrude(height = leg_thickness, center = false)
+            square([axis_length, axis_depth], center = false);
+    } else {
+        linear_extrude(height = leg_thickness, center = false, convexity = 4)
+            hull() {
+                square([r, axis_depth], center = false);
+                square([axis_length, r], center = false);
+                translate([axis_length - r, axis_depth - r, 0])
+                    circle(r = r, $fn = curve_segments);
+            }
+    }
+}
+
+module gusset() {
+    span = min(brace_length, min(leg_length_x, leg_length_y));
+    width = min(brace_width, min(leg_width, span));
+    if (span <= 0 || width <= 0) {
+        return;
+    }
+    if (brace_style == "solid") {
+        gusset_block(span, width);
+    } else if (brace_style == "lightweight") {
+        difference() {
+            gusset_block(span, width);
+            gusset_cutout(span, width);
+        }
+    }
+}
+
+module gusset_block(span, width) {
+    hull() {
+        cube([width, span, leg_thickness], center = false);
+        cube([span, width, leg_thickness], center = false);
+    }
+}
+
+module gusset_cutout(span, width) {
+    cut_center = width + (span - width) / 2;
+    cut_radius = max(width * 0.3, 0.5);
+    translate([cut_center, cut_center, -0.2])
+        cylinder(r = cut_radius, h = leg_thickness + 0.4, center = false, $fn = curve_segments);
+}
+
+module drill_leg_holes(length, width, axis = "x") {
+    margin = hole_diameter / 2 + hole_wall;
+    if (hole_diameter <= 0 || length <= margin * 2) {
+        return;
+    }
+    for (offset_value = hole_offset_list(length, margin)) {
+        if (axis == "x") {
+            translate([offset_value, width / 2, -0.1])
+                cylinder(d = hole_diameter, h = leg_thickness + 0.2, center = false, $fn = curve_segments);
+        } else {
+            translate([width / 2, offset_value, -0.1])
+                cylinder(d = hole_diameter, h = leg_thickness + 0.2, center = false, $fn = curve_segments);
+        }
+    }
+}
+
+function hole_offset_list(length, margin) = use_secondary_hole
+    ? [clamp(primary_hole_offset, margin, length - margin),
+       clamp(secondary_hole_offset, margin, length - margin)]
+    : [clamp(primary_hole_offset, margin, length - margin)];
+
+function clamp_leg_radius(value, max_length, max_width) = value <= 0
+    ? 0
+    : min(value, min(max_length, max_width) / 2 - 0.01);
+
+function clamp(value, lower, upper) = min(max(value, lower), upper);
+
+// Render the bracket
+corner_bracket();

--- a/docs/examples/openscad/emboss_utility.scad
+++ b/docs/examples/openscad/emboss_utility.scad
@@ -1,0 +1,146 @@
+/* [Customizer] STL embossing utility
+
+   This utility script loads an existing STL file (or a generated plate) and
+   embosses text or a 2D design onto its surface.  Parameters exposed through
+   the OpenSCAD customizer make it easy to adjust the position, rotation, and
+   depth of the embellishment.
+*/
+
+// -----------------------------------------------------------------------------
+// Base geometry parameters
+// -----------------------------------------------------------------------------
+use_builtin_plate = true;
+base_model = ""; // Path to an STL that should receive the embossing.
+import_convexity = 10; // [1:1:20]
+
+plate_length = 80; // [30:1:220]
+plate_width = 40; // [20:1:180]
+plate_thickness = 3; // [1:0.2:8]
+plate_corner_radius = 6; // [0:0.5:20]
+plate_segments = 64; // [12:4:128]
+
+// -----------------------------------------------------------------------------
+// Embossing behaviour
+// -----------------------------------------------------------------------------
+emboss_mode = "raised"; // ["raised", "recessed"]
+plane_z = plate_thickness; // [-10:0.5:30]
+engrave_depth = 0.8; // [0.2:0.1:3]
+
+// -----------------------------------------------------------------------------
+// Lettering controls
+// -----------------------------------------------------------------------------
+apply_text = true;
+text_content = "Maker Lab";
+text_font = "Liberation Sans:style=Bold";
+text_size = 12; // [4:1:48]
+text_thickness = 1.2; // [0.4:0.1:4]
+text_spacing = 1.0; // [0.5:0.1:2.0]
+text_halign = "center"; // ["left", "center", "right"]
+text_valign = "center"; // ["baseline", "bottom", "center", "top"]
+text_offset_x = 0; // [-120:1:120]
+text_offset_y = 0; // [-120:1:120]
+text_rotation = 0; // [-180:5:180]
+
+// -----------------------------------------------------------------------------
+// 2D design controls
+// -----------------------------------------------------------------------------
+apply_design = false;
+design_file = ""; // Optional SVG/DXF/2D import for embossing.
+design_scale = 1; // [0.1:0.1:5]
+design_thickness = 1.2; // [0.4:0.1:4]
+design_rotation = 0; // [-180:5:180]
+design_offset_x = 0; // [-120:1:120]
+design_offset_y = 0; // [-120:1:120]
+design_mirror_x = false;
+design_mirror_y = false;
+
+// -----------------------------------------------------------------------------
+// Output assembly
+// -----------------------------------------------------------------------------
+module base_geometry() {
+    if (!use_builtin_plate && base_model != "") {
+        import(base_model, convexity = import_convexity);
+    } else {
+        builtin_plate();
+    }
+}
+
+module builtin_plate() {
+    r = clamp_radius(plate_corner_radius, plate_length, plate_width);
+    lx = max(plate_length - 2 * r, 0.1);
+    ly = max(plate_width - 2 * r, 0.1);
+    linear_extrude(height = plate_thickness, center = false, convexity = import_convexity)
+        offset(r = r, $fn = plate_segments)
+            square([lx, ly], center = true);
+}
+
+module emboss_shapes(mode) {
+    if (apply_text && text_content != "") {
+        text_shape(mode);
+    }
+    if (apply_design && design_file != "") {
+        design_shape(mode);
+    }
+}
+
+module text_shape(mode) {
+    depth = mode == "raised" ? text_thickness : engrave_depth;
+    z_pos = mode == "raised" ? plane_z : plane_z - depth;
+    translate([text_offset_x, text_offset_y, z_pos])
+        rotate([0, 0, text_rotation])
+            linear_extrude(height = depth, center = false, convexity = import_convexity)
+                text(
+                    text_content,
+                    size = text_size,
+                    font = text_font,
+                    halign = text_halign,
+                    valign = text_valign,
+                    spacing = text_spacing
+                );
+}
+
+module design_shape(mode) {
+    depth = mode == "raised" ? design_thickness : engrave_depth;
+    z_pos = mode == "raised" ? plane_z : plane_z - depth;
+    translate([design_offset_x, design_offset_y, z_pos])
+        rotate([0, 0, design_rotation])
+            linear_extrude(height = depth, center = false, convexity = import_convexity)
+                transformed_design_profile();
+}
+
+module transformed_design_profile() {
+    if (design_mirror_x && design_mirror_y) {
+        mirror([1, 0, 0]) mirror([0, 1, 0]) scaled_design_profile();
+    } else if (design_mirror_x) {
+        mirror([1, 0, 0]) scaled_design_profile();
+    } else if (design_mirror_y) {
+        mirror([0, 1, 0]) scaled_design_profile();
+    } else {
+        scaled_design_profile();
+    }
+}
+
+module scaled_design_profile() {
+    scale([design_scale, design_scale, 1])
+        import(design_file, convexity = import_convexity);
+}
+
+module emboss_assembly() {
+    if (emboss_mode == "recessed") {
+        difference() {
+            base_geometry();
+            emboss_shapes("recessed");
+        }
+    } else {
+        union() {
+            base_geometry();
+            emboss_shapes("raised");
+        }
+    }
+}
+
+function clamp_radius(radius, length, width) =
+    radius <= 0 ? 0 : min(radius, min(length, width) / 2 - 0.01);
+
+// Render the final model
+emboss_assembly();


### PR DESCRIPTION
## Summary
- add an OpenSCAD embossing utility that can decorate imported STLs with text or 2D artwork via customizer controls
- provide a parametric corner bracket demo covering leg sizing, gusset options, and mounting hole placement
- document the new example scripts in the OpenSCAD backend notes

## Testing
- `hatch run lint` *(fails: pre-existing style violations in unrelated modules)*
- `hatch run test` *(fails: missing libGL.so.1 dependency for PySide6)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ac0d670c8325a8d927506ffbc357