### PR TITLE
Fix lint violations across project

### DIFF
--- a/src/three_dfs/assembly.py
+++ b/src/three_dfs/assembly.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
-from typing import Any, Iterable, Iterator, Mapping
+from typing import Any
 
 __all__ = ["discover_arrangement_scripts"]
 
@@ -108,7 +109,11 @@ def _iter_arrangement_scripts(root: Path) -> Iterator[Path]:
 
     if root.exists():
         for entry in root.iterdir():
-            if entry.is_file() and entry.suffix.lower() == ".scad" and _looks_like_arrangement(entry):
+            if (
+                entry.is_file()
+                and entry.suffix.lower() == ".scad"
+                and _looks_like_arrangement(entry)
+            ):
                 yield entry
 
 

--- a/src/three_dfs/customizer/__init__.py
+++ b/src/three_dfs/customizer/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence
+from typing import TYPE_CHECKING, Any, Protocol
 
 __all__ = [
     "ParameterDescriptor",
@@ -48,7 +49,7 @@ class ParameterDescriptor:
         }
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> "ParameterDescriptor":
+    def from_dict(cls, data: Mapping[str, Any]) -> ParameterDescriptor:
         """Hydrate a descriptor from :meth:`to_dict` payloads."""
 
         return cls(
@@ -79,12 +80,11 @@ class ParameterSchema:
         }
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> "ParameterSchema":
+    def from_dict(cls, data: Mapping[str, Any]) -> ParameterSchema:
         """Reconstruct a schema from :meth:`to_dict` output."""
 
         parameters = tuple(
-            ParameterDescriptor.from_dict(item)
-            for item in data.get("parameters", [])
+            ParameterDescriptor.from_dict(item) for item in data.get("parameters", [])
         )
         metadata = dict(data.get("metadata") or {})
         return cls(parameters=parameters, metadata=metadata)
@@ -112,7 +112,7 @@ class GeneratedArtifact:
         }
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> "GeneratedArtifact":
+    def from_dict(cls, data: Mapping[str, Any]) -> GeneratedArtifact:
         """Hydrate an artifact instance from stored state."""
 
         return cls(
@@ -154,13 +154,12 @@ class CustomizerSession:
         data: Mapping[str, Any],
         *,
         session_id: int | None = None,
-    ) -> "CustomizerSession":
+    ) -> CustomizerSession:
         """Reconstruct a session from :meth:`to_dict` output."""
 
         schema_data = data.get("schema") or {}
         artifacts = tuple(
-            GeneratedArtifact.from_dict(item)
-            for item in data.get("artifacts", [])
+            GeneratedArtifact.from_dict(item) for item in data.get("artifacts", [])
         )
         command = tuple(str(item) for item in data.get("command", ()))
         return cls(
@@ -196,15 +195,22 @@ class CustomizerBackend(Protocol):
         values: Mapping[str, Any],
         *,
         output_dir: Path,
-        asset_service: "AssetService | None" = None,
+        asset_service: AssetService | None = None,
         execute: bool = False,
         metadata: Mapping[str, Any] | None = None,
     ) -> CustomizerSession:
         """Return a :class:`CustomizerSession` describing the build plan."""
 
 
-from .pipeline import ArtifactResult, PipelineResult, execute_customization  # noqa: E402,I001
-from .status import CustomizationStatus, evaluate_customization_status  # noqa: E402,I001
+from .pipeline import (  # noqa: E402,I001
+    ArtifactResult,
+    PipelineResult,
+    execute_customization,
+)  # noqa: E402,I001
+from .status import (  # noqa: E402,I001
+    CustomizationStatus,
+    evaluate_customization_status,
+)  # noqa: E402,I001
 
 
 if TYPE_CHECKING:  # pragma: no cover - typing helpers

--- a/src/three_dfs/customizer/pipeline.py
+++ b/src/three_dfs/customizer/pipeline.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import mimetypes
 import shutil
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 from ..importer import (
     _allocate_destination,
@@ -306,7 +307,14 @@ def _is_preview_artifact(artifact: GeneratedArtifact, destination: Path) -> bool
     if content_type.startswith("image/"):
         return True
 
-    return destination.suffix.lower() in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+    return destination.suffix.lower() in {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".bmp",
+    }
 
 
 def _build_preview_entries(results: Sequence[ArtifactResult]) -> list[dict[str, Any]]:
@@ -340,4 +348,3 @@ def _build_preview_entries(results: Sequence[ArtifactResult]) -> list[dict[str, 
 def _guess_content_type(path: str) -> str | None:
     mime_type, _ = mimetypes.guess_type(path)
     return mime_type
-

--- a/src/three_dfs/importer.py
+++ b/src/three_dfs/importer.py
@@ -72,7 +72,7 @@ def import_asset(
     *,
     service: AssetService | None = None,
     storage_root: Path | str | None = None,
-) -> "AssetRecord":
+) -> AssetRecord:
     """Import the asset referenced by *path* into managed storage.
 
     Parameters
@@ -147,7 +147,7 @@ def _import_local_asset(
     managed_root: Path,
     *,
     service: AssetService | None,
-) -> "AssetRecord":
+) -> AssetRecord:
     extension = source.suffix.lower()
     if extension not in SUPPORTED_EXTENSIONS:
         raise UnsupportedAssetTypeError(
@@ -179,7 +179,7 @@ def _import_remote_asset(
     *,
     service: AssetService | None,
     attempted_local_resolution: bool,
-) -> "AssetRecord":
+) -> AssetRecord:
     plugin = get_plugin_for(identifier)
     if plugin is None:
         if attempted_local_resolution:
@@ -243,15 +243,12 @@ def _import_remote_asset(
     if extension not in SUPPORTED_EXTENSIONS:
         final_path.unlink(missing_ok=True)
         raise UnsupportedAssetTypeError(
-            "Unsupported asset format "
-            f"'{extension or 'unknown'}' from import plugin"
+            "Unsupported asset format " f"'{extension or 'unknown'}' from import plugin"
         )
 
     plugin_label_value = plugin_metadata.get("label")
     plugin_label = str(plugin_label_value) if plugin_label_value is not None else None
-    plugin_identifier = (
-        f"{plugin.__class__.__module__}.{plugin.__class__.__qualname__}"
-    )
+    plugin_identifier = f"{plugin.__class__.__module__}.{plugin.__class__.__qualname__}"
 
     metadata = {
         "source": identifier,
@@ -299,7 +296,7 @@ def _persist_record(
     *,
     label: str,
     service: AssetService | None,
-) -> "AssetRecord":
+) -> AssetRecord:
     asset_service = service or _default_asset_service()
     try:
         record = asset_service.create_asset(
@@ -373,9 +370,7 @@ def _allocate_destination(storage_root: Path, filename: str) -> Path:
         counter += 1
 
 
-def _resolve_plugin_destination(
-    destination: Path, metadata: Mapping[str, Any]
-) -> Path:
+def _resolve_plugin_destination(destination: Path, metadata: Mapping[str, Any]) -> Path:
     managed_hint = metadata.get("managed_path")
     if managed_hint:
         candidate = Path(str(managed_hint))

--- a/src/three_dfs/storage/database.py
+++ b/src/three_dfs/storage/database.py
@@ -53,7 +53,8 @@ CREATE TABLE IF NOT EXISTS asset_relationships (
 CREATE INDEX IF NOT EXISTS idx_tags_name ON tags(name);
 CREATE INDEX IF NOT EXISTS idx_asset_tag_links_tag_id ON asset_tag_links(tag_id);
 CREATE INDEX IF NOT EXISTS idx_asset_tag_links_asset_id ON asset_tag_links(asset_id);
-CREATE INDEX IF NOT EXISTS idx_customizations_base_asset_id ON customizations(base_asset_id);
+CREATE INDEX IF NOT EXISTS idx_customizations_base_asset_id
+    ON customizations(base_asset_id);
 CREATE INDEX IF NOT EXISTS idx_customizations_backend_identifier
     ON customizations(backend_identifier);
 CREATE INDEX IF NOT EXISTS idx_asset_relationships_base_asset_id

--- a/src/three_dfs/storage/repository.py
+++ b/src/three_dfs/storage/repository.py
@@ -35,7 +35,6 @@ class AssetRecord:
 
 @dataclass(slots=True)
 class CustomizationRecord:
-
     """Represent a customization stored in the database."""
 
     id: int
@@ -386,11 +385,12 @@ class AssetRepository:
         now = datetime.now(UTC)
 
         with self._storage.connect() as connection:
-            customization_row = self._fetch_customization_row(connection, customization_id)
+            customization_row = self._fetch_customization_row(
+                connection,
+                customization_id,
+            )
             if customization_row is None:
-                raise KeyError(
-                    f"Customization {customization_id} does not exist"
-                )
+                raise KeyError(f"Customization {customization_id} does not exist")
             base_asset_id = int(customization_row["base_asset_id"])
 
             connection.execute(
@@ -760,9 +760,7 @@ class AssetRepository:
             (asset_id,),
         ).fetchone()
 
-    def _fetch_customization_row(
-        self, connection: Connection, customization_id: int
-    ):
+    def _fetch_customization_row(self, connection: Connection, customization_id: int):
         return connection.execute(
             "SELECT * FROM customizations WHERE id = ?",
             (customization_id,),
@@ -845,8 +843,6 @@ class AssetRepository:
             created_at=created_at,
             updated_at=updated_at,
         )
-
-
 
     def _row_to_relationship_record(self, row) -> AssetRelationshipRecord:
         created_at = datetime.fromisoformat(row["created_at"])

--- a/src/three_dfs/storage/service.py
+++ b/src/three_dfs/storage/service.py
@@ -2,21 +2,10 @@
 
 from __future__ import annotations
 
-
 import logging
-from pathlib import Path
-
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from typing import Any
-
-
-from .repository import (
-    AssetRecord,
-    AssetRelationshipRecord,
-    AssetRepository,
-    CustomizationRecord,
-)
 
 from ..thumbnails import (
     DEFAULT_THUMBNAIL_SIZE,
@@ -25,8 +14,12 @@ from ..thumbnails import (
     ThumbnailManager,
     ThumbnailResult,
 )
-
-
+from .repository import (
+    AssetRecord,
+    AssetRelationshipRecord,
+    AssetRepository,
+    CustomizationRecord,
+)
 
 __all__ = ["AssetSeed", "AssetService"]
 

--- a/src/three_dfs/ui/__init__.py
+++ b/src/three_dfs/ui/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from .assembly_pane import AssemblyPane
 from .preview_pane import PreviewPane
 from .tag_sidebar import TagSidebar
-from .assembly_pane import AssemblyPane
 
-__all__ = ["PreviewPane", "TagSidebar"]
+__all__ = ["PreviewPane", "TagSidebar", "AssemblyPane"]

--- a/src/three_dfs/ui/customizer_panel.py
+++ b/src/three_dfs/ui/customizer_panel.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
@@ -596,7 +597,10 @@ class CustomizerPanel(QWidget):
                 asset_service=self._asset_service,
             )
         except FileNotFoundError as exc:
-            message = "OpenSCAD executable not found. Ensure it is installed and available on the PATH."
+            message = (
+                "OpenSCAD executable not found. Ensure it is installed "
+                "and available on the PATH."
+            )
             details = str(exc).strip()
             if details:
                 message = f"{message} ({details})"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,12 @@ SRC_DIR = PROJECT_ROOT / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-from three_dfs.config import configure
-
 
 @pytest.fixture(autouse=True)
 def reset_app_config() -> None:
     """Ensure each test runs with the default application configuration."""
+
+    from three_dfs.config import configure
 
     configure(library_root=None)
     yield

--- a/tests/customizer/test_pipeline.py
+++ b/tests/customizer/test_pipeline.py
@@ -165,8 +165,7 @@ def test_execute_customization_registers_artifacts(
     assert customization_meta["relationship"] == "output"
     assert customization_meta["base_asset_label"] == base_asset.label
     assert (
-        customization_meta["base_asset_updated_at"]
-        == base_asset.updated_at.isoformat()
+        customization_meta["base_asset_updated_at"] == base_asset.updated_at.isoformat()
     )
 
     recorded_source = customization_meta.get("source_modified_at")
@@ -195,4 +194,3 @@ def test_execute_customization_registers_artifacts(
         (output_result.asset.id, "output"),
         (preview_result.asset.id, "preview"),
     }
-


### PR DESCRIPTION
## Summary
- reorganize imports and reflow long code paths across the application, storage, and UI modules to satisfy Ruff
- modernize customizer and importer type hints and helper logic while cleaning up multi-statement lines
- adjust tests to avoid top-level imports prior to sys.path setup and apply Black formatting to touched files

## Testing
- `ruff check src tests`
- `black --check src tests`
- `pytest` *(fails: libGL.so.1 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1be60d7a88325a4cb08dcf557e12c