### PR TITLE
Fix assembly pane context menu actions

### DIFF
--- a/src/three_dfs/app.py
+++ b/src/three_dfs/app.py
@@ -63,6 +63,7 @@ class MainWindow(QMainWindow):
         self._assembly_pane = AssemblyPane(self)
         self._assembly_pane.setObjectName("assemblyPane")
         # Wire assembly pane actions
+        self._assembly_pane.newPartRequested.connect(self._create_new_part)
         self._assembly_pane.addAttachmentsRequested.connect(
             self._add_assembly_attachments
         )


### PR DESCRIPTION
## Summary
- remove the duplicated context menu helper from the icon worker and keep the AssemblyPane implementation with all actions
- move the placeholder icon helper onto AssemblyPane so placeholder components still render an icon
- connect AssemblyPane.newPartRequested to MainWindow._create_new_part so the context menu action opens the new part dialog

## Testing
- hatch run lint *(fails: command not found)*
- hatch run test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eaf71ce48325aeaa79edb4369fae