### PR TITLE
Enable navigating to nested assemblies

### DIFF
--- a/tests/test_ui_assembly_pane.py
+++ b/tests/test_ui_assembly_pane.py
@@ -1,0 +1,107 @@
+"""Tests exercising the assembly pane navigation helpers."""
+
+from __future__ import annotations
+
+from three_dfs.ui.assembly_pane import AssemblyComponent, AssemblyPane
+
+
+def _capture_navigation(pane: AssemblyPane) -> list[str]:
+    captured: list[str] = []
+    pane.navigateToPathRequested.connect(captured.append)
+    return captured
+
+
+def test_component_activation_emits_navigation_for_placeholder(tmp_path, qapp):
+    pane = AssemblyPane()
+    try:
+        child_dir = tmp_path / "child"
+        child_dir.mkdir()
+        component = AssemblyComponent(
+            path=str(child_dir),
+            label="Child",
+            kind="placeholder",
+        )
+
+        pane.set_assembly(str(tmp_path), label="Root", components=[component])
+        captured = _capture_navigation(pane)
+        item = pane._components.item(0)
+        assert item is not None
+
+        pane._components.itemActivated.emit(item)
+
+        assert captured == [str(child_dir.resolve())]
+    finally:
+        pane.deleteLater()
+        qapp.processEvents()
+
+
+def test_component_activation_emits_navigation_for_directory_component(tmp_path, qapp):
+    pane = AssemblyPane()
+    try:
+        sub_dir = tmp_path / "sub"
+        sub_dir.mkdir()
+        component = AssemblyComponent(
+            path=str(sub_dir),
+            label="Sub",
+            kind="component",
+        )
+
+        pane.set_assembly(str(tmp_path), label="Root", components=[component])
+        captured = _capture_navigation(pane)
+        item = pane._components.item(0)
+        assert item is not None
+
+        pane._components.itemActivated.emit(item)
+
+        assert captured == [str(sub_dir.resolve())]
+    finally:
+        pane.deleteLater()
+        qapp.processEvents()
+
+
+def test_component_activation_ignores_file_components(tmp_path, qapp):
+    pane = AssemblyPane()
+    try:
+        part_file = tmp_path / "part.3mf"
+        part_file.write_text("dummy")
+        component = AssemblyComponent(
+            path=str(part_file),
+            label="Part",
+            kind="component",
+        )
+
+        pane.set_assembly(str(tmp_path), label="Root", components=[component])
+        captured = _capture_navigation(pane)
+        item = pane._components.item(0)
+        assert item is not None
+
+        pane._components.itemActivated.emit(item)
+
+        assert captured == []
+    finally:
+        pane.deleteLater()
+        qapp.processEvents()
+
+
+def test_component_activation_resolves_relative_placeholder_paths(tmp_path, qapp):
+    pane = AssemblyPane()
+    try:
+        relative_dir = tmp_path / "relative"
+        relative_dir.mkdir()
+        component = AssemblyComponent(
+            path="relative",
+            label="Relative",
+            kind="placeholder",
+        )
+
+        pane.set_assembly(str(tmp_path), label="Root", components=[component])
+        captured = _capture_navigation(pane)
+        item = pane._components.item(0)
+        assert item is not None
+
+        pane._components.itemActivated.emit(item)
+
+        assert captured == [str(relative_dir.resolve())]
+    finally:
+        pane.deleteLater()
+        qapp.processEvents()


### PR DESCRIPTION
## Summary
- allow double-clicking and the context-menu “Open Assembly” option in the assembly pane to emit navigation requests for directories, placeholders, and assembly-tagged items
- add a helper that resolves component targets before emitting `navigateToPathRequested`
- cover the new behaviour with unit tests for placeholder, directory, file, and relative paths

## Testing
- hatch run lint
- QT_QPA_PLATFORM=offscreen hatch run test *(fails: tests/customizer/test_pipeline.py::test_execute_customization_registers_artifacts because the recorded source timestamp differs by a few microseconds)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ed890bbc8325b0f3f56d861a3658