### PR TITLE
Support existing assets in customizer pipeline

### DIFF
--- a/docs/customizer_backends.md
+++ b/docs/customizer_backends.md
@@ -46,3 +46,10 @@ Build123D-based workflow—only requires translating that tool's metadata into a
 engine should be executed.  The resulting `CustomizerSession` integrates with
 the shared execution pipeline, enabling consistent storage and reproducibility
 across all backends.
+
+Backends that rely on auxiliary resources (for example Build123D Python
+scripts) can declare these dependencies by returning `GeneratedArtifact`
+entries with the `asset_id` field populated.  The pipeline links such artifacts
+to the customization without copying or mutating the original asset metadata,
+allowing reproducible builds while keeping script sources managed alongside
+their owning library entries.

--- a/tests/customizer/test_pipeline.py
+++ b/tests/customizer/test_pipeline.py
@@ -104,6 +104,64 @@ class StubBackend(CustomizerBackend):
         )
 
 
+@dataclass(slots=True)
+class ScriptReferenceBackend(StubBackend):
+    """Stub backend that also links an existing Python script artifact."""
+
+    script_asset_id: int | None = None
+    script_path: Path | None = None
+
+    def plan_build(
+        self,
+        source: Path,
+        schema: ParameterSchema,
+        values: Mapping[str, Any],
+        *,
+        output_dir: Path,
+        asset_service: AssetService | None = None,
+        execute: bool = False,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> CustomizerSession:
+        session = super().plan_build(
+            source,
+            schema,
+            values,
+            output_dir=output_dir,
+            asset_service=asset_service,
+            execute=execute,
+            metadata=metadata,
+        )
+
+        artifacts = list(session.artifacts)
+        if self.script_asset_id is not None and self.script_path is not None:
+            artifacts.append(
+                GeneratedArtifact(
+                    path=str(self.script_path),
+                    label="Build123 Script",
+                    relationship="script",
+                    asset_id=self.script_asset_id,
+                    content_type="text/x-python",
+                )
+            )
+
+        session_metadata = dict(session.metadata)
+        if self.script_path is not None:
+            session_metadata.setdefault("python", {})
+            python_meta = dict(session_metadata["python"])
+            python_meta.setdefault("scripts", []).append(str(self.script_path))
+            session_metadata["python"] = python_meta
+
+        return CustomizerSession(
+            base_asset_path=session.base_asset_path,
+            schema=session.schema,
+            parameters=dict(session.parameters),
+            command=session.command,
+            artifacts=tuple(artifacts),
+            session_id=session.session_id,
+            metadata=session_metadata,
+        )
+
+
 @pytest.fixture()
 def asset_service(tmp_path: Path) -> AssetService:
     storage = SQLiteStorage(tmp_path / "assets.sqlite3")
@@ -194,3 +252,81 @@ def test_execute_customization_registers_artifacts(
         (output_result.asset.id, "output"),
         (preview_result.asset.id, "preview"),
     }
+
+
+def test_execute_customization_links_python_script(
+    tmp_path: Path, asset_service: AssetService
+) -> None:
+    backend = ScriptReferenceBackend()
+
+    script_path = tmp_path / "scripts" / "customizer.py"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    script_path.write_text("print('build123 script')\n", encoding="utf-8")
+
+    script_asset = asset_service.create_asset(
+        str(script_path),
+        label="Customizer Script",
+        metadata={"kind": "python-script"},
+    )
+
+    backend.script_asset_id = script_asset.id
+    backend.script_path = script_path
+
+    base_source = tmp_path / "sources" / "base_model.scad"
+    base_source.parent.mkdir(parents=True, exist_ok=True)
+    base_source.write_text("module stub() {}\n", encoding="utf-8")
+
+    base_asset = asset_service.create_asset(
+        str(base_source),
+        label="Base Fixture",
+        metadata={"managed_path": str(base_source), "source_type": "local"},
+    )
+
+    library_root = tmp_path / "library"
+
+    result = execute_customization(
+        base_asset,
+        backend,
+        {"size": 1.5},
+        asset_service=asset_service,
+        storage_root=library_root,
+    )
+
+    artifacts_by_relationship = {
+        item.artifact.relationship: item for item in result.artifacts
+    }
+    assert set(artifacts_by_relationship) == {"output", "preview", "script"}
+
+    script_result = artifacts_by_relationship["script"]
+    assert script_result.asset.id == script_asset.id
+    assert Path(script_result.asset.path) == script_path
+    assert script_result.asset.metadata == script_asset.metadata
+
+    expected_root = (
+        library_root
+        / "customizations"
+        / str(base_asset.id)
+        / str(result.customization.id)
+    )
+
+    output_result = artifacts_by_relationship["output"]
+    assert Path(output_result.asset.path).parent == expected_root
+    preview_result = artifacts_by_relationship["preview"]
+    assert Path(preview_result.asset.path).parent == expected_root
+
+    relationships = asset_service.repository.list_relationships_for_base_asset(
+        base_asset.id
+    )
+    mapping = {
+        (relation.generated_asset_id, relation.relationship_type)
+        for relation in relationships
+    }
+    assert mapping == {
+        (output_result.asset.id, "output"),
+        (preview_result.asset.id, "preview"),
+        (script_asset.id, "script"),
+    }
+
+    stored_script = asset_service.repository.get_asset(script_asset.id)
+    assert stored_script is not None
+    assert stored_script.metadata == script_asset.metadata


### PR DESCRIPTION
## Summary
- allow `execute_customization` to link existing assets referenced by `GeneratedArtifact.asset_id`
- guard preview metadata refreshes so only artifacts belonging to the current customization are updated
- document the workflow for Build123D scripts and add regression coverage for script artifacts

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68d3edd980288325829165e34f4f9105