### PR TITLE
Refactor customizer transformations to use build123d

### DIFF
--- a/docs/customizer_transformations.md
+++ b/docs/customizer_transformations.md
@@ -1,0 +1,81 @@
+# Customizer mesh transformations
+
+The :mod:`three_dfs.customizer.transformations` module provides reusable
+building blocks that backends can compose into their build plans.  Each
+transformation is described by a lightweight descriptor object which exposes a
+``to_dict`` method so plans can be persisted alongside other customization
+metadata.  During execution the descriptors are applied to a source mesh using
+``apply_transformations`` which relies on :mod:`build123d` for CAD operations
+and emits both STL meshes and companion OpenSCAD snippets that mirror the
+transformation pipeline.  Structured metadata such as bounding boxes and
+component statistics are recorded alongside the exported assets.
+
+## Available operations
+
+The following descriptors are available for backends:
+
+* ``ScaleTransformation`` – perform uniform or axis-aligned scaling.  Optional
+  ``origin`` values allow scaling around a specific reference point.
+* ``TranslateTransformation`` – offset the current mesh by an ``(x, y, z)``
+  vector.
+* ``EmbossMeshTransformation`` – load another mesh from disk, optionally scale
+  and translate it, then emboss the result onto the base geometry.  Component
+  statistics are captured alongside the combined bounding box.
+* ``EmbossTextTransformation`` – generate 3D text with ``build123d`` primitives
+  and emboss it onto the base mesh.  The helper centres extruded text around
+  the origin so descriptors can position the lettering precisely while still
+  emitting component metadata for storage.
+* ``BooleanUnionTransformation`` – boolean union between the current mesh and
+  one or more external meshes using ``build123d``'s solid modelling kernels.
+
+All descriptors expose ``to_dict``/``from_dict`` helpers via
+``serialise_descriptors`` and ``descriptor_from_dict`` so build plans can be
+recorded within :class:`three_dfs.customizer.CustomizerSession` metadata.
+
+## Example build plan payload
+
+Backends can persist transformation pipelines as JSON payloads.  The following
+example highlights a scale/translate sequence followed by text embossing and a
+boolean union with an auxiliary mesh.  The snippet matches the structure
+returned by ``serialise_descriptors``::
+
+    {
+      "operations": [
+        {
+          "operation": "scale",
+          "factors": [1.25, 1.0, 0.8]
+        },
+        {
+          "operation": "translate",
+          "offset": [0.0, 0.0, 5.0]
+        },
+        {
+          "operation": "emboss_text",
+          "text": "Part 42",
+          "height": 2.0,
+          "depth": 0.4,
+          "position": [10.0, 0.0, 6.2]
+        },
+        {
+          "operation": "boolean_union",
+          "mesh_paths": ["./fixtures/fasteners/logo.stl"]
+        }
+      ]
+    }
+
+When the plan executes ``apply_transformations`` returns metadata capturing each
+operation's descriptor along with statistics for the transformed mesh:
+
+* ``operations`` – ordered list of per-operation metadata including the
+  original descriptor parameters and bounding boxes.
+* ``bounding_box_min`` / ``bounding_box_max`` – extents for the final mesh.
+* ``vertex_count`` / ``face_count`` – totals for the resulting geometry.
+* ``backend`` – identifies the modelling engine used (``build123d``).
+* ``openscad_script`` – a runnable OpenSCAD representation of the applied
+  transformations, allowing downstream tooling to re-run the pipeline if
+  desired.
+* ``units`` – unit metadata derived from the source mesh when available.
+
+Backends can store the metadata directly within the customization session so
+the UI or downstream automation can reconstruct the applied steps and inspect
+the resulting geometry without re-running the backend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
   "PySide6>=6.7",
   "Pillow>=10.3",
+  "build123d>=0.9",
   "numpy>=1.26",
   "SQLAlchemy>=2.0",
   "trimesh>=4.4",

--- a/src/three_dfs/customizer/transformations.py
+++ b/src/three_dfs/customizer/transformations.py
@@ -1,0 +1,670 @@
+"""Reusable mesh transformation utilities powered by build123d."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, ClassVar, TypeVar
+
+try:  # pragma: no cover - optional dependency exercised in tests
+    from build123d import (
+        Align,
+        BoundBox,
+        Compound,
+        Matrix,
+        Mesher,
+        Shape,
+        Vector,
+        export_stl,
+    )
+    from build123d.build_enums import Unit
+except ImportError:  # pragma: no cover - dependency availability varies
+    Align = BoundBox = Compound = Matrix = Mesher = Shape = Vector = export_stl = None  # type: ignore[assignment]
+    Unit = None  # type: ignore[assignment]
+    _BUILD123D_AVAILABLE = False
+else:  # pragma: no cover - exercised via tests
+    _BUILD123D_AVAILABLE = True
+
+__all__ = [
+    "TransformationDescriptor",
+    "ScaleTransformation",
+    "TranslateTransformation",
+    "EmbossMeshTransformation",
+    "EmbossTextTransformation",
+    "BooleanUnionTransformation",
+    "descriptor_from_dict",
+    "serialise_descriptors",
+    "apply_transformations",
+]
+
+
+_DescriptorType = TypeVar("_DescriptorType", bound="TransformationDescriptor")
+
+
+class TransformationError(RuntimeError):
+    """Raised when a transformation cannot be applied."""
+
+
+@dataclass(slots=True)
+class _TransformationContext:
+    """Execution context shared between transformation descriptors."""
+
+    units: str
+
+
+def _require_build123d() -> None:
+    if not _BUILD123D_AVAILABLE:  # pragma: no cover - guarded by import checks
+        raise TransformationError(
+            "build123d is required to apply customizer transformations"
+        )
+
+
+def _vector(values: Iterable[float], *, components: int) -> tuple[float, ...]:
+    sequence = tuple(float(value) for value in values)
+    if len(sequence) != components:
+        raise ValueError(f"Expected {components} components, received {sequence!r}")
+    return sequence
+
+
+def _format_scad_vector(values: Iterable[float]) -> str:
+    components = [f"{float(value):.6g}" for value in values]
+    return f"[{', '.join(components)}]"
+
+
+def _translation_matrix(offset: Iterable[float]) -> Matrix:
+    _require_build123d()
+    x, y, z = _vector(offset, components=3)
+    return Matrix(
+        [
+            [1.0, 0.0, 0.0, x],
+            [0.0, 1.0, 0.0, y],
+            [0.0, 0.0, 1.0, z],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+
+
+def _scale_matrix(factors: Iterable[float]) -> Matrix:
+    _require_build123d()
+    sx, sy, sz = _vector(factors, components=3)
+    return Matrix(
+        [
+            [sx, 0.0, 0.0, 0.0],
+            [0.0, sy, 0.0, 0.0],
+            [0.0, 0.0, sz, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+
+
+def _ensure_shape(candidate: Any) -> Shape:
+    if hasattr(candidate, "bounding_box"):
+        return candidate
+    if isinstance(candidate, Sequence):
+        if not candidate:
+            raise TransformationError("Boolean operation returned no geometry")
+        if len(candidate) == 1:
+            return candidate[0]
+        _require_build123d()
+        return Compound(candidate)
+    raise TransformationError("Unsupported geometry result from boolean operation")
+
+
+def _combine_shapes(shapes: Sequence[Shape]) -> Shape:
+    iterator = iter(shapes)
+    try:
+        combined = next(iterator)
+    except StopIteration as exc:  # pragma: no cover - defensive guard
+        raise TransformationError("No shapes were loaded from the mesh") from exc
+
+    for shape in iterator:
+        combined = _ensure_shape(combined.fuse(shape))
+
+    return combined
+
+
+def _shape_units(mesher: Mesher) -> str:
+    unit = getattr(mesher, "unit", None)
+    if unit is None:
+        return "unspecified"
+    if isinstance(unit, Unit):
+        return unit.name.lower()
+    return str(unit)
+
+
+def _shape_metadata(shape: Shape, *, units: str) -> dict[str, Any]:
+    bbox: BoundBox = shape.bounding_box()
+    min_corner = (float(bbox.min.X), float(bbox.min.Y), float(bbox.min.Z))
+    max_corner = (float(bbox.max.X), float(bbox.max.Y), float(bbox.max.Z))
+    vertices = shape.vertices()
+    faces = shape.faces()
+    return {
+        "vertex_count": len(vertices),
+        "face_count": len(faces),
+        "bounding_box_min": [float(value) for value in min_corner],
+        "bounding_box_max": [float(value) for value in max_corner],
+        "units": units,
+    }
+
+
+def _load_shape(path: Path) -> tuple[Shape, str]:
+    _require_build123d()
+    mesher = Mesher()
+    shapes = mesher.read(str(path))
+    if not shapes:
+        raise TransformationError(f"Unable to load mesh from {path!s}")
+    return _combine_shapes(shapes), _shape_units(mesher)
+
+
+def _apply_matrix(shape: Shape, matrix: Matrix) -> Shape:
+    return shape.transform_geometry(matrix)
+
+
+def _fuse_shapes(base: Shape, additions: Sequence[Shape]) -> Shape:
+    combined = base
+    for addition in additions:
+        combined = _ensure_shape(combined.fuse(addition))
+    return combined
+
+
+def _create_text_shape(
+    text: str,
+    *,
+    height: float,
+    depth: float,
+    font: str | None = None,
+    spacing: float = 1.0,
+) -> Shape:
+    _require_build123d()
+    if not text:
+        raise ValueError("text must not be empty")
+    outline = Compound.make_text(
+        txt=text,
+        font_size=height,
+        font=font or "Arial",
+        align=(Align.CENTER, Align.CENTER),
+    )
+    solid = Compound.extrude(outline, Vector(0.0, 0.0, depth))
+    solid = _apply_matrix(solid, _translation_matrix((0.0, 0.0, -depth / 2.0)))
+    if spacing != 1.0:
+        solid = _apply_matrix(solid, _scale_matrix((spacing, 1.0, 1.0)))
+    return solid
+
+
+class TransformationDescriptor(ABC):
+    """Base class describing a mesh transformation."""
+
+    operation: ClassVar[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["operation"] = self.operation
+        return payload
+
+    @classmethod
+    def from_dict(
+        cls: type[_DescriptorType], data: Mapping[str, Any]
+    ) -> _DescriptorType:
+        operation = data.get("operation")
+        if not operation:
+            raise ValueError("Transformation descriptor missing 'operation'")
+
+        descriptor_cls = _TRANSFORMATION_REGISTRY.get(str(operation))
+        if descriptor_cls is None:
+            raise ValueError(f"Unsupported transformation operation: {operation!r}")
+
+        return descriptor_cls._from_dict(data)
+
+    @classmethod
+    @abstractmethod
+    def _from_dict(
+        cls: type[_DescriptorType], data: Mapping[str, Any]
+    ) -> _DescriptorType:
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply(
+        self, shape: Shape, context: _TransformationContext
+    ) -> tuple[Shape, dict[str, Any]]:
+        """Return a transformed shape and associated metadata."""
+
+    def parameter_dict(self) -> dict[str, Any]:
+        payload = self.to_dict().copy()
+        payload.pop("operation", None)
+        return payload
+
+    def openscad_module(self, previous: str, index: int) -> tuple[str, str]:
+        """Return an OpenSCAD module definition and its exported name."""
+
+        return "", previous
+
+
+_TRANSFORMATION_REGISTRY: dict[str, type[TransformationDescriptor]] = {}
+
+
+def _register_descriptor(
+    cls: type[_DescriptorType],
+) -> type[_DescriptorType]:
+    _TRANSFORMATION_REGISTRY[cls.operation] = cls
+    return cls
+
+
+@dataclass(slots=True)
+@_register_descriptor
+class ScaleTransformation(TransformationDescriptor):
+    """Uniform or axis-aligned scaling of a shape."""
+
+    factors: tuple[float, float, float]
+    origin: tuple[float, float, float] | None = None
+
+    operation: ClassVar[str] = "scale"
+
+    @classmethod
+    def _from_dict(cls, data: Mapping[str, Any]) -> ScaleTransformation:
+        factors = _vector(data.get("factors", (1.0, 1.0, 1.0)), components=3)
+        origin_data = data.get("origin")
+        origin = None
+        if origin_data is not None:
+            origin = _vector(origin_data, components=3)
+        return cls(factors=factors, origin=origin)
+
+    def apply(
+        self, shape: Shape, context: _TransformationContext
+    ) -> tuple[Shape, dict[str, Any]]:
+        _require_build123d()
+
+        transformed = shape
+        if self.origin is not None:
+            inverse_origin = tuple(-value for value in self.origin)
+            transformed = _apply_matrix(
+                transformed, _translation_matrix(inverse_origin)
+            )
+        transformed = _apply_matrix(transformed, _scale_matrix(self.factors))
+        if self.origin is not None:
+            transformed = _apply_matrix(transformed, _translation_matrix(self.origin))
+
+        metadata = {
+            "operation": self.operation,
+            "parameters": self.parameter_dict(),
+            **_shape_metadata(transformed, units=context.units),
+        }
+        return transformed, metadata
+
+    def openscad_module(self, previous: str, index: int) -> tuple[str, str]:
+        module_name = f"op{index}"
+        lines = [f"module {module_name}() {{"]
+        indent = "    "
+        if self.origin is not None:
+            lines.append(f"{indent}translate({_format_scad_vector(self.origin)}) {{")
+            indent += "    "
+        lines.append(f"{indent}scale({_format_scad_vector(self.factors)}) {{")
+        indent += "    "
+        if self.origin is not None:
+            inverse = tuple(-value for value in self.origin)
+            lines.append(f"{indent}translate({_format_scad_vector(inverse)}) {{")
+            indent += "    "
+        lines.append(f"{indent}{previous}();")
+        if self.origin is not None:
+            indent = indent[:-4]
+            lines.append(f"{indent}}}")
+        indent = indent[:-4]
+        lines.append(f"{indent}}}")
+        if self.origin is not None:
+            indent = indent[:-4]
+            lines.append(f"{indent}}}")
+        lines.append("}")
+        return "\n".join(lines), module_name
+
+
+@dataclass(slots=True)
+@_register_descriptor
+class TranslateTransformation(TransformationDescriptor):
+    """Translate a shape by the given offset."""
+
+    offset: tuple[float, float, float]
+
+    operation: ClassVar[str] = "translate"
+
+    @classmethod
+    def _from_dict(cls, data: Mapping[str, Any]) -> TranslateTransformation:
+        offset = _vector(data.get("offset", (0.0, 0.0, 0.0)), components=3)
+        return cls(offset=offset)
+
+    def apply(
+        self, shape: Shape, context: _TransformationContext
+    ) -> tuple[Shape, dict[str, Any]]:
+        _require_build123d()
+        transformed = _apply_matrix(shape, _translation_matrix(self.offset))
+        metadata = {
+            "operation": self.operation,
+            "parameters": self.parameter_dict(),
+            **_shape_metadata(transformed, units=context.units),
+        }
+        return transformed, metadata
+
+    def openscad_module(self, previous: str, index: int) -> tuple[str, str]:
+        module_name = f"op{index}"
+        lines = [
+            f"module {module_name}() {{",
+            f"    translate({_format_scad_vector(self.offset)}) {{",
+            f"        {previous}();",
+            "    }",
+            "}",
+        ]
+        return "\n".join(lines), module_name
+
+
+@dataclass(slots=True)
+@_register_descriptor
+class EmbossMeshTransformation(TransformationDescriptor):
+    """Emboss an external mesh onto the base geometry."""
+
+    mesh_path: str
+    position: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    scale: tuple[float, float, float] | float = 1.0
+
+    operation: ClassVar[str] = "emboss_mesh"
+
+    @classmethod
+    def _from_dict(cls, data: Mapping[str, Any]) -> EmbossMeshTransformation:
+        position = _vector(data.get("position", (0.0, 0.0, 0.0)), components=3)
+        mesh_path = str(data.get("mesh_path", "")).strip()
+        if not mesh_path:
+            raise ValueError("mesh_path is required for emboss mesh transformations")
+        scale_data = data.get("scale", 1.0)
+        if isinstance(scale_data, int | float):
+            scale: tuple[float, float, float] | float = float(scale_data)
+        else:
+            scale = _vector(scale_data, components=3)
+        return cls(mesh_path=mesh_path, position=position, scale=scale)
+
+    def _apply_scale(self, shape: Shape) -> Shape:
+        factors = (
+            (float(self.scale), float(self.scale), float(self.scale))
+            if isinstance(self.scale, int | float)
+            else self.scale
+        )
+        return _apply_matrix(shape, _scale_matrix(factors))
+
+    def apply(
+        self, shape: Shape, context: _TransformationContext
+    ) -> tuple[Shape, dict[str, Any]]:
+        _require_build123d()
+        addition, addition_units = _load_shape(Path(self.mesh_path))
+        addition = self._apply_scale(addition)
+        addition = _apply_matrix(addition, _translation_matrix(self.position))
+        combined = _fuse_shapes(shape, (addition,))
+        metadata = {
+            "operation": self.operation,
+            "parameters": self.parameter_dict(),
+            "component": _shape_metadata(addition, units=addition_units),
+            **_shape_metadata(combined, units=context.units),
+        }
+        return combined, metadata
+
+    def openscad_module(self, previous: str, index: int) -> tuple[str, str]:
+        module_name = f"op{index}"
+        if isinstance(self.scale, int | float):
+            factors = (float(self.scale),) * 3
+        else:
+            factors = self.scale
+        mesh = Path(self.mesh_path).as_posix()
+        lines = [
+            f"module {module_name}() {{",
+            "    union() {",
+            f"        {previous}();",
+            "        translate({_format_scad_vector(self.position)}) {",
+            f"            scale({_format_scad_vector(factors)}) {{",
+            f'                import("{mesh}");',
+            "            }",
+            "        }",
+            "    }",
+            "}",
+        ]
+        return "\n".join(lines), module_name
+
+
+@dataclass(slots=True)
+@_register_descriptor
+class EmbossTextTransformation(TransformationDescriptor):
+    """Create and emboss 3D text onto the base shape."""
+
+    text: str
+    height: float = 1.0
+    depth: float = 0.5
+    position: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    font: str | None = None
+    spacing: float = 1.0
+
+    operation: ClassVar[str] = "emboss_text"
+
+    @classmethod
+    def _from_dict(cls, data: Mapping[str, Any]) -> EmbossTextTransformation:
+        text = str(data.get("text", "")).strip()
+        if not text:
+            raise ValueError("text is required for emboss text transformations")
+        position = _vector(data.get("position", (0.0, 0.0, 0.0)), components=3)
+        font = data.get("font")
+        return cls(
+            text=text,
+            height=float(data.get("height", 1.0)),
+            depth=float(data.get("depth", 0.5)),
+            position=position,
+            font=str(font) if font is not None else None,
+            spacing=float(data.get("spacing", 1.0)),
+        )
+
+    def apply(
+        self, shape: Shape, context: _TransformationContext
+    ) -> tuple[Shape, dict[str, Any]]:
+        _require_build123d()
+        text_shape = _create_text_shape(
+            self.text,
+            height=self.height,
+            depth=self.depth,
+            font=self.font,
+            spacing=self.spacing,
+        )
+        text_shape = _apply_matrix(text_shape, _translation_matrix(self.position))
+        combined = _fuse_shapes(shape, (text_shape,))
+        metadata = {
+            "operation": self.operation,
+            "parameters": self.parameter_dict(),
+            "component": _shape_metadata(text_shape, units=context.units),
+            **_shape_metadata(combined, units=context.units),
+        }
+        return combined, metadata
+
+    def openscad_module(self, previous: str, index: int) -> tuple[str, str]:
+        module_name = f"op{index}"
+        font_clause = f', font="{self.font}"' if self.font else ""
+        text_call = (
+            f'text("{self.text}", size={self.height:.6g}{font_clause}, '
+            f'halign="center", valign="center", spacing={self.spacing:.6g});'
+        )
+        lines = [
+            f"module {module_name}() {{",
+            "    union() {",
+            f"        {previous}();",
+            f"        translate({_format_scad_vector(self.position)}) {{",
+            f"            linear_extrude(height={self.depth:.6g}) {{",
+            f"                {text_call}",
+            "            }",
+            "        }",
+            "    }",
+            "}",
+        ]
+        return "\n".join(lines), module_name
+
+
+@dataclass(slots=True)
+@_register_descriptor
+class BooleanUnionTransformation(TransformationDescriptor):
+    """Boolean union between the base shape and external meshes."""
+
+    mesh_paths: tuple[str, ...]
+
+    operation: ClassVar[str] = "boolean_union"
+
+    @classmethod
+    def _from_dict(cls, data: Mapping[str, Any]) -> BooleanUnionTransformation:
+        mesh_paths = tuple(str(path) for path in data.get("mesh_paths", ()))
+        if not mesh_paths:
+            raise ValueError("mesh_paths must contain at least one entry")
+        return cls(mesh_paths=mesh_paths)
+
+    def apply(
+        self, shape: Shape, context: _TransformationContext
+    ) -> tuple[Shape, dict[str, Any]]:
+        _require_build123d()
+        additions: list[Shape] = []
+        components_metadata: list[dict[str, Any]] = []
+        for path_str in self.mesh_paths:
+            addition, addition_units = _load_shape(Path(path_str))
+            additions.append(addition)
+            components_metadata.append(_shape_metadata(addition, units=addition_units))
+        combined = _fuse_shapes(shape, additions)
+        metadata = {
+            "operation": self.operation,
+            "parameters": self.parameter_dict(),
+            "components": components_metadata,
+            **_shape_metadata(combined, units=context.units),
+        }
+        return combined, metadata
+
+    def openscad_module(self, previous: str, index: int) -> tuple[str, str]:
+        module_name = f"op{index}"
+        lines = [
+            f"module {module_name}() {{",
+            "    union() {",
+            f"        {previous}();",
+        ]
+        for mesh_path in self.mesh_paths:
+            lines.append(f'        import("{Path(mesh_path).as_posix()}");')
+        lines.append("    }")
+        lines.append("}")
+        return "\n".join(lines), module_name
+
+
+def descriptor_from_dict(data: Mapping[str, Any]) -> TransformationDescriptor:
+    """Hydrate a descriptor instance from stored metadata."""
+
+    return TransformationDescriptor.from_dict(data)
+
+
+def serialise_descriptors(
+    descriptors: Sequence[TransformationDescriptor],
+) -> list[dict[str, Any]]:
+    """Return a JSON-serialisable representation of *descriptors*."""
+
+    return [descriptor.to_dict() for descriptor in descriptors]
+
+
+def _normalise_descriptors(
+    descriptors: Sequence[TransformationDescriptor | Mapping[str, Any]],
+) -> list[TransformationDescriptor]:
+    normalised: list[TransformationDescriptor] = []
+    for descriptor in descriptors:
+        if isinstance(descriptor, TransformationDescriptor):
+            normalised.append(descriptor)
+        else:
+            normalised.append(descriptor_from_dict(descriptor))
+    return normalised
+
+
+def _export_shape(
+    shape: Shape,
+    target_path: Path,
+    export_kwargs: Mapping[str, Any] | None,
+) -> None:
+    suffix = target_path.suffix.lower()
+    if suffix != ".stl":
+        raise TransformationError(
+            f"Unsupported export format '{suffix or 'unknown'}'; only STL is supported"
+        )
+
+    parameters = dict(export_kwargs or {})
+    tolerance = float(parameters.pop("tolerance", 1e-3))
+    angular_tolerance = float(parameters.pop("angular_tolerance", 0.1))
+    ascii_format = bool(parameters.pop("ascii_format", False))
+    if parameters:
+        unknown = ", ".join(sorted(parameters))
+        raise TransformationError(f"Unsupported export parameters: {unknown}")
+
+    export_stl(
+        shape,
+        str(target_path),
+        tolerance=tolerance,
+        angular_tolerance=angular_tolerance,
+        ascii_format=ascii_format,
+    )
+
+
+def _initial_scad_module(source: Path) -> tuple[str, str]:
+    module_name = "op0"
+    lines = [
+        f"module {module_name}() {{",
+        f'    import("{source.as_posix()}");',
+        "}",
+    ]
+    return "\n".join(lines), module_name
+
+
+def apply_transformations(
+    source: str | Path,
+    transformations: Sequence[TransformationDescriptor | Mapping[str, Any]],
+    *,
+    output_path: str | Path,
+    export_kwargs: Mapping[str, Any] | None = None,
+    scad_output: str | Path | None = None,
+) -> dict[str, Any]:
+    """Apply *transformations* to *source* and persist the resulting mesh."""
+
+    _require_build123d()
+
+    source_path = Path(source)
+    shape, units = _load_shape(source_path)
+    context = _TransformationContext(units=units)
+
+    operations_metadata: list[dict[str, Any]] = []
+    current_shape = shape
+
+    scad_modules: list[str] = []
+    module_definition, previous_module = _initial_scad_module(source_path)
+    scad_modules.append(module_definition)
+
+    for index, descriptor in enumerate(
+        _normalise_descriptors(transformations), start=1
+    ):
+        current_shape, metadata = descriptor.apply(current_shape, context)
+        module_definition, module_name = descriptor.openscad_module(
+            previous_module, index
+        )
+        if module_definition:
+            scad_modules.append(module_definition)
+            metadata["openscad_module"] = module_name
+            previous_module = module_name
+        operations_metadata.append(metadata)
+
+    scad_modules.append(f"{previous_module}();")
+    scad_script = "\n\n".join(scad_modules)
+
+    output_target = Path(output_path)
+    output_target.parent.mkdir(parents=True, exist_ok=True)
+    _export_shape(current_shape, output_target, export_kwargs)
+
+    if scad_output is not None:
+        Path(scad_output).write_text(scad_script, encoding="utf-8")
+
+    result_metadata = {
+        "source": str(source_path),
+        "output": str(output_target),
+        "backend": "build123d",
+        "operations": operations_metadata,
+        "openscad_script": scad_script,
+        **_shape_metadata(current_shape, units=context.units),
+    }
+
+    return result_metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,11 @@ import sys
 from pathlib import Path
 
 import pytest
-from PySide6.QtWidgets import QApplication
+
+try:  # pragma: no cover - dependency availability varies between environments
+    from PySide6.QtWidgets import QApplication
+except ImportError:  # pragma: no cover - used when Qt is unavailable
+    QApplication = None  # type: ignore[assignment]
 
 # Ensure the source directory is importable without requiring an editable install.
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -29,6 +33,9 @@ def reset_app_config() -> None:
 @pytest.fixture(scope="session")
 def qapp():
     """Provide a ``QApplication`` instance for UI-oriented tests."""
+
+    if QApplication is None:
+        pytest.skip("PySide6 is unavailable in this environment")
 
     app = QApplication.instance()
     if app is None:

--- a/tests/customizer/test_transformations.py
+++ b/tests/customizer/test_transformations.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:  # pragma: no cover - exercised when build123d is unavailable
+    from build123d import (
+        Align,
+        Box,
+        BuildPart,
+        Cylinder,
+        Sphere,
+        Vector,
+        export_stl,
+    )
+except ImportError:  # pragma: no cover - used in CI when dependency missing
+    pytest.skip(
+        "build123d is required for transformation tests", allow_module_level=True
+    )
+
+from three_dfs.customizer.transformations import (
+    BooleanUnionTransformation,
+    EmbossMeshTransformation,
+    EmbossTextTransformation,
+    ScaleTransformation,
+    TranslateTransformation,
+    apply_transformations,
+    descriptor_from_dict,
+    serialise_descriptors,
+)
+
+
+def _export_shape(shape, path: Path) -> Path:
+    export_stl(shape, str(path))
+    return path
+
+
+@pytest.fixture()
+def base_mesh_path(tmp_path: Path) -> Path:
+    with BuildPart() as part:
+        Box(1.0, 1.0, 1.0, align=Align.CENTER)
+    return _export_shape(part.part, tmp_path / "base.stl")
+
+
+def test_scale_and_translate(base_mesh_path: Path, tmp_path: Path) -> None:
+    output = tmp_path / "scaled_translated.stl"
+
+    metadata = apply_transformations(
+        base_mesh_path,
+        [
+            ScaleTransformation(factors=(2.0, 1.0, 0.5)),
+            TranslateTransformation(offset=(1.0, -2.0, 0.25)),
+        ],
+        output_path=output,
+    )
+
+    assert output.exists()
+    assert metadata["backend"] == "build123d"
+    assert len(metadata["operations"]) == 2
+    assert "scale([2" in metadata["openscad_script"]
+
+    # After scaling the base cube (-0.5..0.5) we expect dimensions of
+    # (-1..1, -0.5..0.5, -0.25..0.25). The translation shifts the bounds.
+    expected_min = np.array([-1.0, -0.5, -0.25]) + np.array([1.0, -2.0, 0.25])
+    expected_max = np.array([1.0, 0.5, 0.25]) + np.array([1.0, -2.0, 0.25])
+
+    assert metadata["bounding_box_min"] == pytest.approx(expected_min.tolist())
+    assert metadata["bounding_box_max"] == pytest.approx(expected_max.tolist())
+
+
+def test_boolean_union_combines_meshes(base_mesh_path: Path, tmp_path: Path) -> None:
+    with BuildPart() as part:
+        Sphere(radius=0.4)
+    sphere_shape = part.part.translate(Vector(1.2, 0.0, 0.0))
+    sphere_path = _export_shape(sphere_shape, tmp_path / "sphere.stl")
+
+    output = tmp_path / "union.stl"
+
+    metadata = apply_transformations(
+        base_mesh_path,
+        [BooleanUnionTransformation(mesh_paths=(str(sphere_path),))],
+        output_path=output,
+    )
+
+    assert output.exists()
+    assert metadata["operations"][0]["operation"] == "boolean_union"
+
+    bounding_min = np.array(metadata["bounding_box_min"])
+    bounding_max = np.array(metadata["bounding_box_max"])
+
+    # Ensure the union includes both the cube and the translated sphere.
+    assert bounding_min[0] <= -0.5
+    assert bounding_max[0] >= 1.6
+
+
+def test_emboss_mesh_records_component_metadata(
+    base_mesh_path: Path, tmp_path: Path
+) -> None:
+    with BuildPart() as part:
+        Cylinder(
+            radius=0.2, height=0.6, align=(Align.CENTER, Align.CENTER, Align.CENTER)
+        )
+    cylinder_path = _export_shape(part.part, tmp_path / "cylinder.stl")
+
+    output = tmp_path / "emboss_mesh.stl"
+
+    metadata = apply_transformations(
+        base_mesh_path,
+        [
+            EmbossMeshTransformation(
+                mesh_path=str(cylinder_path),
+                position=(0.0, 0.0, 0.5),
+                scale=(1.0, 1.0, 1.0),
+            )
+        ],
+        output_path=output,
+    )
+
+    assert output.exists()
+
+    operation = metadata["operations"][0]
+    assert operation["operation"] == "emboss_mesh"
+    assert "component" in operation
+    assert operation["component"]["vertex_count"] > 0
+
+    # The cylinder sits on top of the cube. Ensure the combined mesh grew along Z.
+    assert metadata["bounding_box_max"][2] > 0.5
+
+
+def test_emboss_text_generates_geometry(base_mesh_path: Path, tmp_path: Path) -> None:
+    output = tmp_path / "emboss_text.stl"
+
+    depth = 0.2
+    # Place the text so it protrudes above the cube by half its depth.
+    z_position = 0.5 + depth / 2.0
+
+    metadata = apply_transformations(
+        base_mesh_path,
+        [
+            EmbossTextTransformation(
+                text="A",
+                height=0.5,
+                depth=depth,
+                position=(0.0, 0.0, z_position),
+            )
+        ],
+        output_path=output,
+    )
+
+    assert output.exists()
+
+    operation = metadata["operations"][0]
+    assert operation["operation"] == "emboss_text"
+    assert operation["component"]["vertex_count"] > 0
+    assert metadata["bounding_box_max"][2] == pytest.approx(z_position + depth / 2.0)
+
+
+def test_descriptor_serialisation_round_trip() -> None:
+    descriptors = [
+        ScaleTransformation(factors=(1.5, 1.0, 1.0)),
+        TranslateTransformation(offset=(0.0, 0.0, 1.0)),
+        EmbossTextTransformation(text="Hello", height=0.3, depth=0.1),
+    ]
+
+    payload = serialise_descriptors(descriptors)
+    hydrated = [descriptor_from_dict(item) for item in payload]
+
+    assert [item.to_dict() for item in hydrated] == payload


### PR DESCRIPTION
## Summary
- reimplement the customizer transformation pipeline on top of build123d, exporting STL meshes and OpenSCAD scripts while tracking metadata through a shared context
- add build123d as a project dependency, refresh the advanced workflow documentation, and surface the backend/opencad details in the reported metadata
- update the transformation tests to build simple fixtures with build123d and guard them when the dependency is unavailable

## Testing
- pytest tests/customizer/test_transformations.py

------
https://chatgpt.com/codex/tasks/task_e_68d3efe39c908325a376e4266c5ff9b6