### PR TITLE
Add customizer UI and derivative navigation

### DIFF
--- a/docs/customizer_backends.md
+++ b/docs/customizer_backends.md
@@ -38,6 +38,22 @@ utility for embossing arbitrary STL files (`emboss_utility.scad`) and a
 demonstration corner bracket (`demo_parametric_bracket.scad`) that highlights a
 variety of parameter types available to the customizer.
 
+## Desktop workflow
+
+The desktop shell now surfaces customization metadata directly within the
+preview pane. Selecting a supported source file (for example an OpenSCAD
+script) enables the **Customize…** action and presents a summary panel that
+lists recent derivative artefacts along with the parameters that produced
+them.  The summary includes quick-launch buttons so you can jump to generated
+assets or reopen the customizer dialog pre-populated with the previous
+settings.
+
+Launching the dialog instantiates the embedded `CustomizerPanel` inside a
+modal window, preserving the familiar sliders and toggles while delegating run
+execution to `execute_customization`.  Successful runs automatically refresh
+the preview summary and the new derivatives list in the tag sidebar, keeping
+related artefacts one click away without requiring a manual library rescan.
+
 ## Adapting additional engines
 
 Extending the system to support another parametric modelling engine—such as a

--- a/docs/manual_testing.md
+++ b/docs/manual_testing.md
@@ -1,0 +1,10 @@
+# Manual testing checklist
+
+## Customizer dialog smoke test
+
+1. Launch the desktop shell (`hatch run three-dfs`).
+2. Select a parametric source asset such as `docs/examples/openscad/demo_parametric_bracket.scad`.
+3. Confirm the preview pane shows the customization summary with a **Customize…** button.
+4. Click **Customize…** to open the dialog and adjust a parameter (for example change the `segments` slider).
+5. Trigger the build and verify that a success message appears summarising the generated artefact count.
+6. Back in the preview pane ensure the derivatives list reflects the newly created output and the tag sidebar shows the derivative entry.

--- a/src/three_dfs/customizer/pipeline.py
+++ b/src/three_dfs/customizer/pipeline.py
@@ -256,7 +256,7 @@ def _build_asset_metadata(
     generated_at = datetime.now(UTC).isoformat()
     try:
         source_modified_at = datetime.fromtimestamp(
-            source_path.stat().st_mtime,
+            Path(base_asset.path).stat().st_mtime,
             tz=UTC,
         ).isoformat()
     except OSError:

--- a/src/three_dfs/ui/__init__.py
+++ b/src/three_dfs/ui/__init__.py
@@ -5,5 +5,6 @@ from __future__ import annotations
 from .assembly_pane import AssemblyPane
 from .preview_pane import PreviewPane
 from .tag_sidebar import TagSidebar
+from .customizer_dialog import CustomizerDialog
 
-__all__ = ["PreviewPane", "TagSidebar", "AssemblyPane"]
+__all__ = ["PreviewPane", "TagSidebar", "AssemblyPane", "CustomizerDialog"]

--- a/src/three_dfs/ui/customizer_dialog.py
+++ b/src/three_dfs/ui/customizer_dialog.py
@@ -1,0 +1,97 @@
+"""Dialog wrapper around :class:`CustomizerPanel` for customization runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Any
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout
+
+from ..customizer import CustomizerBackend, ParameterSchema
+from ..storage import AssetRecord, AssetService
+from .customizer_panel import CustomizerPanel
+
+__all__ = ["CustomizerDialog", "CustomizerSessionConfig"]
+
+
+@dataclass(slots=True)
+class CustomizerSessionConfig:
+    """Describe the state required to launch a customization session."""
+
+    backend: CustomizerBackend
+    schema: ParameterSchema
+    source_path: Path
+    base_asset: AssetRecord
+    values: Mapping[str, Any] | None = None
+    customization_id: int | None = None
+
+
+class CustomizerDialog(QDialog):
+    """Modal dialog exposing customizer controls for a backend."""
+
+    customizationStarted = Signal()
+    customizationSucceeded = Signal(object)
+    customizationFailed = Signal(str)
+
+    def __init__(
+        self,
+        *,
+        asset_service: AssetService,
+        parent: QDialog | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._asset_service = asset_service
+        self._config: CustomizerSessionConfig | None = None
+
+        self._panel = CustomizerPanel(asset_service=self._asset_service, parent=self)
+        self._panel.customizationStarted.connect(self.customizationStarted)
+        self._panel.customizationSucceeded.connect(self._handle_success)
+        self._panel.customizationFailed.connect(self.customizationFailed)
+
+        self._button_box = QDialogButtonBox(QDialogButtonBox.Close, self)
+        self._button_box.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
+        layout.addWidget(self._panel)
+        layout.addWidget(self._button_box)
+
+        self.setModal(True)
+        self.resize(520, 620)
+
+    # ------------------------------------------------------------------
+    # Session management
+    # ------------------------------------------------------------------
+    def set_session(self, config: CustomizerSessionConfig) -> None:
+        """Populate the dialog with *config* data."""
+
+        self._config = config
+        base_label = config.base_asset.label or Path(config.base_asset.path).name
+        self.setWindowTitle(f"Customize {base_label}")
+        self._panel.set_session(
+            backend=config.backend,
+            schema=config.schema,
+            source_path=config.source_path,
+            base_asset=config.base_asset,
+            values=config.values,
+        )
+
+    def session_config(self) -> CustomizerSessionConfig | None:
+        """Return the configuration currently applied to the dialog."""
+
+        return self._config
+
+    def panel(self) -> CustomizerPanel:
+        """Expose the underlying :class:`CustomizerPanel` instance."""
+
+        return self._panel
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _handle_success(self, result: object) -> None:
+        self.customizationSucceeded.emit(result)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import pytest
 from PySide6.QtWidgets import QApplication

--- a/tests/customizer/test_customizer_frontend.py
+++ b/tests/customizer/test_customizer_frontend.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from PySide6.QtTest import QSignalSpy
 
 from three_dfs.customizer.openscad import OpenSCADBackend
+from three_dfs.storage import AssetRepository, AssetService, SQLiteStorage
+from three_dfs.data import TagStore
+from three_dfs.ui.customizer_dialog import CustomizerDialog, CustomizerSessionConfig
 from three_dfs.ui.customizer_panel import (
     BooleanParameterWidget,
     ChoiceParameterWidget,
@@ -12,10 +16,18 @@ from three_dfs.ui.customizer_panel import (
     NumberParameterWidget,
     RangeParameterWidget,
 )
+from three_dfs.ui.preview_pane import PreviewPane
+from three_dfs.ui.tag_sidebar import TagSidebar
 
 
 def _fixture_path(name: str) -> Path:
     return Path(__file__).resolve().parent / "data" / name
+
+
+def _create_asset_service(root: Path) -> AssetService:
+    storage = SQLiteStorage(root / "assets.sqlite3")
+    repository = AssetRepository(storage)
+    return AssetService(repository)
 
 
 def test_customizer_panel_renders_schema(qapp):
@@ -69,3 +81,142 @@ def test_customizer_panel_renders_schema(qapp):
     reset_values = panel.parameter_values()
     assert reset_values["segments"] == 12
     assert reset_values["material"] == "plastic"
+
+
+def test_customizer_dialog_configures_panel(qapp, tmp_path):
+    backend = OpenSCADBackend()
+    source = _fixture_path("example.scad")
+    target = tmp_path / "example.scad"
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    service = _create_asset_service(tmp_path)
+    base_asset = service.create_asset(str(target), label="Example Part")
+    schema = backend.load_schema(target)
+
+    config = CustomizerSessionConfig(
+        backend=backend,
+        schema=schema,
+        source_path=target,
+        base_asset=base_asset,
+        values={"segments": 8},
+    )
+
+    dialog = CustomizerDialog(asset_service=service)
+    dialog.set_session(config)
+
+    assert "Example Part" in dialog.windowTitle()
+    assert dialog.panel().parameter_names() == tuple(
+        descriptor.name for descriptor in schema.parameters
+    )
+    assert dialog.panel().parameter_values()["segments"] == 8
+    dialog.close()
+
+
+def test_preview_pane_displays_customization_summary(qapp, tmp_path):
+    backend = OpenSCADBackend()
+    source = _fixture_path("example.scad")
+    target = tmp_path / "example.scad"
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    service = _create_asset_service(tmp_path)
+    base_asset = service.create_asset(str(target), label="Example")
+    schema = backend.load_schema(target)
+    customization = service.create_customization(
+        str(target),
+        backend_identifier="openscad",
+        parameter_schema=schema.to_dict(),
+        parameter_values={"segments": 12},
+    )
+
+    derivative_path = tmp_path / "example_output.stl"
+    derivative_path.write_text("mesh", encoding="utf-8")
+    derivative_metadata = {
+        "customization": {
+            "id": customization.id,
+            "backend": "openscad",
+            "base_asset_path": str(target),
+            "relationship": "output",
+            "parameters": {"segments": 12},
+        }
+    }
+    service.record_derivative(
+        customization.id,
+        str(derivative_path),
+        relationship_type="output",
+        label="Output",
+        metadata=derivative_metadata,
+    )
+
+    preview = PreviewPane(base_path=tmp_path, asset_service=service)
+    preview._enqueue_preview = lambda path: None
+
+    preview.set_item(
+        str(target),
+        label=base_asset.label,
+        metadata=base_asset.metadata,
+        asset_record=base_asset,
+    )
+    preview.show()
+    qapp.processEvents()
+
+    assert preview.can_customize is True
+    summary_text = preview._customization_summary_label.text().lower()
+    assert "customized artifact" in summary_text
+    assert preview._customize_button.isVisible()
+    assert preview._customization_action_buttons
+
+    first_button = preview._customization_action_buttons[0]
+    spy = QSignalSpy(preview.navigationRequested)
+    first_button.click()
+    qapp.processEvents()
+    assert spy.count() == 1
+    assert spy.at(0)[0] == str(derivative_path)
+    preview.deleteLater()
+
+
+def test_tag_sidebar_lists_derivatives(qapp, tmp_path):
+    service = _create_asset_service(tmp_path)
+    store = TagStore(service=service)
+
+    source = tmp_path / "item.scad"
+    source.write_text("module test() {}", encoding="utf-8")
+    base_asset = service.create_asset(str(source), label="Item")
+    customization = service.create_customization(
+        str(source),
+        backend_identifier="openscad",
+        parameter_schema={},
+        parameter_values={},
+    )
+    derivative_path = tmp_path / "item_output.stl"
+    derivative_path.write_text("mesh", encoding="utf-8")
+    derivative_metadata = {
+        "customization": {
+            "id": customization.id,
+            "backend": "openscad",
+            "base_asset_path": str(source),
+            "relationship": "output",
+        }
+    }
+    service.record_derivative(
+        customization.id,
+        str(derivative_path),
+        relationship_type="output",
+        label="Output",
+        metadata=derivative_metadata,
+    )
+
+    sidebar = TagSidebar(store, asset_service=service)
+    sidebar.set_active_item(str(base_asset.path))
+    sidebar.show()
+    qapp.processEvents()
+
+    assert sidebar._derivative_list.isVisible()
+    assert sidebar._derivative_list.count() == 1
+    item = sidebar._derivative_list.item(0)
+
+    spy = QSignalSpy(sidebar.derivativeActivated)
+    sidebar._derivative_list.itemActivated.emit(item)
+    qapp.processEvents()
+    assert spy.count() == 1
+    assert spy.at(0)[0] == str(derivative_path)
+    sidebar.deleteLater()


### PR DESCRIPTION
## Summary
- add a reusable `CustomizerDialog` that wraps the existing panel and exposes customization signals for the preview pane
- surface customization summaries, derivative quick actions, and navigation handling throughout the preview pane and main window
- list derivative assets in the tag sidebar, expand UI tests, and document the new workflow and manual checks

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68d3f5a3de008325b29872f9f9450b68