### PR TITLE
Refactor storage root resolution into shared utility

### DIFF
--- a/src/three_dfs/customizer/pipeline.py
+++ b/src/three_dfs/customizer/pipeline.py
@@ -15,6 +15,7 @@ from ..importer import (
     _resolve_plugin_destination,
     default_storage_root,
 )
+from ..paths import resolve_storage_root
 from ..storage import (
     AssetRecord,
     AssetRelationshipRecord,
@@ -75,7 +76,10 @@ def execute_customization(
         debugging purposes.
     """
 
-    managed_root = _resolve_storage_root(storage_root)
+    managed_root = resolve_storage_root(
+        storage_root,
+        default=default_storage_root,
+    )
     base_path = _resolve_source_path(base_asset)
     backend_identifier = _backend_identifier(backend)
 
@@ -225,18 +229,6 @@ def execute_customization(
     finally:
         if cleanup:
             shutil.rmtree(work_directory, ignore_errors=True)
-
-
-def _resolve_storage_root(storage_root: str | Path | None) -> Path:
-    if storage_root is None:
-        return default_storage_root()
-
-    candidate = Path(storage_root).expanduser()
-    if not candidate.is_absolute():
-        candidate = candidate.resolve()
-    return candidate
-
-
 def _resolve_source_path(base_asset: AssetRecord) -> Path:
     candidates: list[Path] = []
     metadata = getattr(base_asset, "metadata", {}) or {}

--- a/src/three_dfs/importer.py
+++ b/src/three_dfs/importer.py
@@ -18,6 +18,7 @@ except ImportError:  # pragma: no cover - dependency guaranteed in production
 
 from .config import get_config
 from .import_plugins import get_plugin_for
+from .paths import resolve_storage_root
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checking only
     from .storage import AssetRecord, AssetService
@@ -109,7 +110,10 @@ def import_asset(
                 raise AssetImportError(f"Asset {resolved!s} is not a file")
             source = resolved
 
-    managed_root = _resolve_storage_root(storage_root)
+    managed_root = resolve_storage_root(
+        storage_root,
+        default=default_storage_root,
+    )
     imported_at = datetime.now(UTC).isoformat()
 
     if source is not None:
@@ -128,18 +132,6 @@ def import_asset(
         service=service,
         attempted_local_resolution=attempted_local_resolution,
     )
-
-
-def _resolve_storage_root(storage_root: Path | str | None) -> Path:
-    if storage_root is None:
-        return default_storage_root()
-
-    candidate = Path(storage_root).expanduser()
-    if not candidate.is_absolute():
-        candidate = candidate.resolve()
-    return candidate
-
-
 def _import_local_asset(
     source: Path,
     identifier: str,

--- a/src/three_dfs/paths.py
+++ b/src/three_dfs/paths.py
@@ -1,0 +1,38 @@
+"""Shared path utilities used across three_dfs modules."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+__all__ = ["resolve_storage_root"]
+
+
+def resolve_storage_root(
+    storage_root: Path | str | None,
+    *,
+    default: Path | Callable[[], Path],
+) -> Path:
+    """Return the managed storage root for importer-style operations.
+
+    Parameters
+    ----------
+    storage_root:
+        Optional override supplied by the caller. When provided the value is
+        expanded, converted to an absolute path, and resolved. Relative paths
+        are interpreted relative to the current working directory.
+    default:
+        Default managed storage location used when *storage_root* is omitted.
+        The value can be a :class:`~pathlib.Path` instance or a zero-argument
+        callable returning one. The callable form is useful when the default
+        depends on configuration that should be resolved lazily.
+    """
+
+    if storage_root is None:
+        return default() if callable(default) else default
+
+    candidate = Path(storage_root).expanduser()
+    if not candidate.is_absolute():
+        candidate = candidate.resolve()
+    return candidate
+


### PR DESCRIPTION
## Summary
- add a three_dfs.paths module with resolve_storage_root to centralize storage root normalization
- update the importer and customization pipeline to rely on the shared utility instead of duplicating logic

## Testing
- python -m hatch run lint *(fails: existing import sorting/style violations in unrelated modules)*
- python -m hatch run test *(fails: PySide6 tests require system libGL.so.1 which is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d40d9327c88325add78ec23dfd924b