### PR TITLE
Add issue templates for bug, feature, and documentation requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: "Bug report"
+description: "Report a reproducible problem in 3DFS"
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for letting us know about a problem! Fill out all required fields so we can help quickly.
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we reach you if we need more info?
+      placeholder: "@github-handle or email"
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the issue.
+      placeholder: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Step-by-step instructions to trigger the bug.
+      placeholder: |
+        1. Run '...'
+        2. Click '...'
+        3. Bug happens
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+      placeholder: "Describe the expected outcome."
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+      placeholder: "Describe the current outcome, including error messages."
+    validations:
+      required: true
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression
+      description: Did this work in a previous version of 3DFS?
+      options:
+        - "Unknown"
+        - "No, this never worked"
+        - "Yes, it used to work"
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include details such as OS, Python version, install method, and any relevant dependencies.
+      placeholder: |
+        - OS: macOS 14.5
+        - Python: 3.11.4
+        - Installation: pip
+        - Additional context: using Apple Silicon
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs & screenshots
+      description: Paste relevant console output, stack traces, or screenshots.
+      render: shell
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Anything else we should know?

--- a/.github/ISSUE_TEMPLATE/docs_update.yml
+++ b/.github/ISSUE_TEMPLATE/docs_update.yml
@@ -1,0 +1,30 @@
+name: "Docs update"
+description: "Suggest fixes or additions to the documentation"
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us keep the documentation accurate and up to date.
+  - type: input
+    id: location
+    attributes:
+      label: Affected docs
+      description: Which page, section, or file needs attention?
+      placeholder: "e.g., README.md - Installation section"
+    validations:
+      required: true
+  - type: textarea
+    id: change
+    attributes:
+      label: Requested change
+      description: Describe what needs to be updated or clarified.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Share screenshots, links, or references that explain the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: "Feature request"
+description: "Propose a new idea or enhancement for 3DFS"
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tell us about the new capability you would like to see in 3DFS. Clear use-cases help us plan work.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+      placeholder: "I want to... but currently..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you would like. Include APIs, workflows, or UI mocks if available.
+      placeholder: "Add a command that..."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you explored other approaches or workarounds?
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Any extra details, screenshots, or references.


### PR DESCRIPTION
## Summary
- add GitHub issue form templates for bug reports, feature requests, and documentation updates
- capture the key details we need to triage each type of submission

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d411dcf08483258c934e22836d0ef7