### PR TITLE
Centralize asset metadata assembly

### DIFF
--- a/src/three_dfs/storage/__init__.py
+++ b/src/three_dfs/storage/__init__.py
@@ -1,6 +1,7 @@
 """SQLite-backed persistence utilities for 3dfs asset metadata."""
 
 from .database import DEFAULT_DB_PATH, SQLiteStorage
+from .metadata import build_asset_metadata
 from .repository import (
     AssetRecord,
     AssetRelationshipRecord,
@@ -15,6 +16,7 @@ __all__ = [
     "AssetRepository",
     "AssetSeed",
     "AssetService",
+    "build_asset_metadata",
     "CustomizationRecord",
     "DEFAULT_DB_PATH",
     "SQLiteStorage",

--- a/src/three_dfs/storage/metadata.py
+++ b/src/three_dfs/storage/metadata.py
@@ -1,0 +1,75 @@
+"""Helpers for constructing asset metadata payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+__all__ = ["build_asset_metadata"]
+
+
+def build_asset_metadata(
+    *,
+    source: str | Path,
+    source_type: str,
+    managed_path: str | Path,
+    original_path: str | Path | None = None,
+    size: int | float | None = None,
+    timestamps: Mapping[str, Any] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a metadata dictionary with normalized core asset fields.
+
+    Parameters
+    ----------
+    source:
+        Identifier for where the asset originated.
+    source_type:
+        Classifier describing how the asset was produced (``"local"``,
+        ``"remote"``, ``"customization"``, etc.).
+    managed_path:
+        Filesystem location of the persisted asset under managed storage.
+    original_path:
+        Optional pointer to the original source material. When omitted the
+        *source* value is reused.
+    size:
+        Known byte size for the managed asset. When omitted the size is read
+        from ``managed_path``.
+    timestamps:
+        Mapping of timestamp keys (``"imported_at"``, ``"generated_at"``, ...)
+        to values. Falsy values are ignored.
+    extra:
+        Additional key/value pairs merged into the resulting metadata.
+    """
+
+    original = original_path if original_path is not None else source
+    metadata: dict[str, Any] = {
+        "source": _stringify(source),
+        "source_type": str(source_type),
+        "original_path": _stringify(original),
+        "managed_path": _stringify(managed_path),
+        "size": _resolve_size(managed_path, size),
+    }
+
+    if timestamps:
+        for key, value in timestamps.items():
+            if value:
+                metadata[str(key)] = _stringify(value)
+
+    if extra:
+        metadata.update(extra)
+
+    return metadata
+
+
+def _resolve_size(path: str | Path, explicit_size: int | float | None) -> int:
+    if explicit_size is not None:
+        return int(explicit_size)
+
+    resolved = Path(path)
+    return resolved.stat().st_size
+
+
+def _stringify(value: str | Path | Any) -> str:
+    return str(value)


### PR DESCRIPTION
## Summary
- add a shared `build_asset_metadata` helper under `three_dfs.storage.metadata` for consistent asset metadata
- refactor the importer and customization pipeline to create metadata dictionaries via the shared helper
- re-export the helper from `three_dfs.storage` so callers have a single entry point

## Testing
- hatch run lint *(fails: existing Ruff import-order violations outside the touched modules)*
- hatch run test *(fails: environment missing libGL for PySide6-based UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d41b550cac8325ad54375a6ac76bf5