### PR TITLE
Skip PySide6 UI tests when Qt runtime missing

### DIFF
--- a/tests/customizer/test_customizer_frontend.py
+++ b/tests/customizer/test_customizer_frontend.py
@@ -3,21 +3,33 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from PySide6.QtTest import QSignalSpy
 
-from three_dfs.customizer.openscad import OpenSCADBackend
-from three_dfs.data import TagStore
-from three_dfs.storage import AssetRepository, AssetService, SQLiteStorage
-from three_dfs.ui.customizer_dialog import CustomizerDialog, CustomizerSessionConfig
-from three_dfs.ui.customizer_panel import (
-    BooleanParameterWidget,
-    ChoiceParameterWidget,
-    CustomizerPanel,
-    NumberParameterWidget,
-    RangeParameterWidget,
-)
-from three_dfs.ui.preview_pane import PreviewPane
-from three_dfs.ui.tag_sidebar import TagSidebar
+pytest.importorskip("PySide6")
+
+try:  # pragma: no cover - guarded to skip gracefully on headless CI
+    from PySide6.QtTest import QSignalSpy
+
+    from three_dfs.customizer.openscad import OpenSCADBackend
+    from three_dfs.data import TagStore
+    from three_dfs.storage import AssetRepository, AssetService, SQLiteStorage
+    from three_dfs.ui.customizer_dialog import CustomizerDialog, CustomizerSessionConfig
+    from three_dfs.ui.customizer_panel import (
+        BooleanParameterWidget,
+        ChoiceParameterWidget,
+        CustomizerPanel,
+        NumberParameterWidget,
+        RangeParameterWidget,
+    )
+    from three_dfs.ui.preview_pane import PreviewPane
+    from three_dfs.ui.tag_sidebar import TagSidebar
+except ImportError as exc:  # pragma: no cover - skip when Qt libs missing
+    message = str(exc)
+    if "PySide6" in message or "libGL" in message or "libEGL" in message:
+        pytest.skip(
+            f"PySide6 runtime dependencies unavailable: {message}",
+            allow_module_level=True,
+        )
+    raise
 
 
 def _fixture_path(name: str) -> Path:

--- a/tests/customizer/test_pipeline.py
+++ b/tests/customizer/test_pipeline.py
@@ -122,7 +122,8 @@ class ScriptReferenceBackend(StubBackend):
         execute: bool = False,
         metadata: Mapping[str, Any] | None = None,
     ) -> CustomizerSession:
-        session = super().plan_build(
+        session = StubBackend.plan_build(
+            self,
             source,
             schema,
             values,

--- a/tests/test_ui_assembly_pane.py
+++ b/tests/test_ui_assembly_pane.py
@@ -4,9 +4,22 @@ from __future__ import annotations
 
 from typing import Any
 
-from PySide6.QtCore import Qt
+import pytest
 
-from three_dfs.ui.assembly_pane import AssemblyComponent, AssemblyPane
+pytest.importorskip("PySide6")
+
+try:  # pragma: no cover - import guarded for CI environments lacking Qt runtime
+    from PySide6.QtCore import Qt
+
+    from three_dfs.ui.assembly_pane import AssemblyComponent, AssemblyPane
+except ImportError as exc:  # pragma: no cover - skip when Qt system libs are missing
+    message = str(exc)
+    if "PySide6" in message or "libGL" in message or "libEGL" in message:
+        pytest.skip(
+            f"PySide6 runtime dependencies unavailable: {message}",
+            allow_module_level=True,
+        )
+    raise
 
 
 def _capture_navigation(pane: AssemblyPane) -> list[str]:


### PR DESCRIPTION
## Summary
- guard PySide6-dependent test modules so they skip cleanly when Qt system libraries such as libGL/libEGL are unavailable
- adjust the customizer pipeline stub backend used in tests to invoke the parent plan implementation without relying on `super()`

## Testing
- hatch run test
- ruff check tests

------
https://chatgpt.com/codex/tasks/task_e_68d43f511a008325bacacd851ee6b561