### PR TITLE
Handle missing PySide6 dependencies in tests

### DIFF
--- a/src/three_dfs/customizer/__init__.py
+++ b/src/three_dfs/customizer/__init__.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "ParameterDescriptor",
@@ -173,33 +174,69 @@ class CustomizerSession:
         )
 
 
-class CustomizerBackend(Protocol):
-    """Common interface implemented by customization backends."""
+if TYPE_CHECKING:
+    from typing import Protocol as _CustomizerBackendProtocol
 
-    name: str
+    class CustomizerBackend(_CustomizerBackendProtocol):
+        """Common interface implemented by customization backends."""
 
-    def load_schema(self, source: Path) -> ParameterSchema:
-        """Inspect *source* and return a :class:`ParameterSchema`."""
+        name: str
 
-    def validate(
-        self,
-        schema: ParameterSchema,
-        values: Mapping[str, Any],
-    ) -> dict[str, Any]:
-        """Validate *values* against *schema* returning normalized data."""
+        def load_schema(self, source: Path) -> ParameterSchema:
+            """Inspect *source* and return a :class:`ParameterSchema`."""
 
-    def plan_build(
-        self,
-        source: Path,
-        schema: ParameterSchema,
-        values: Mapping[str, Any],
-        *,
-        output_dir: Path,
-        asset_service: AssetService | None = None,
-        execute: bool = False,
-        metadata: Mapping[str, Any] | None = None,
-    ) -> CustomizerSession:
-        """Return a :class:`CustomizerSession` describing the build plan."""
+        def validate(
+            self,
+            schema: ParameterSchema,
+            values: Mapping[str, Any],
+        ) -> dict[str, Any]:
+            """Validate *values* against *schema* returning normalized data."""
+
+        def plan_build(
+            self,
+            source: Path,
+            schema: ParameterSchema,
+            values: Mapping[str, Any],
+            *,
+            output_dir: Path,
+            asset_service: AssetService | None = None,
+            execute: bool = False,
+            metadata: Mapping[str, Any] | None = None,
+        ) -> CustomizerSession:
+            """Return a :class:`CustomizerSession` describing the build plan."""
+
+else:
+
+    class CustomizerBackend(ABC):
+        """Common interface implemented by customization backends."""
+
+        name: str
+
+        @abstractmethod
+        def load_schema(self, source: Path) -> ParameterSchema:
+            """Inspect *source* and return a :class:`ParameterSchema`."""
+
+        @abstractmethod
+        def validate(
+            self,
+            schema: ParameterSchema,
+            values: Mapping[str, Any],
+        ) -> dict[str, Any]:
+            """Validate *values* against *schema* returning normalized data."""
+
+        @abstractmethod
+        def plan_build(
+            self,
+            source: Path,
+            schema: ParameterSchema,
+            values: Mapping[str, Any],
+            *,
+            output_dir: Path,
+            asset_service: AssetService | None = None,
+            execute: bool = False,
+            metadata: Mapping[str, Any] | None = None,
+        ) -> CustomizerSession:
+            """Return a :class:`CustomizerSession` describing the build plan."""
 
 
 from .pipeline import (  # noqa: E402,I001

--- a/tests/customizer/test_customizer_frontend.py
+++ b/tests/customizer/test_customizer_frontend.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
+pytest.importorskip("PySide6.QtTest", exc_type=ImportError)
+pytest.importorskip("PySide6.QtWidgets", exc_type=ImportError)
+
 from PySide6.QtTest import QSignalSpy
 
 from three_dfs.customizer.openscad import OpenSCADBackend

--- a/tests/customizer/test_pipeline.py
+++ b/tests/customizer/test_pipeline.py
@@ -25,7 +25,7 @@ _MINIMAL_PNG = (
 )
 
 
-@dataclass(slots=True)
+@dataclass
 class StubBackend(CustomizerBackend):
     """Test backend that emits a mesh artifact and a preview image."""
 
@@ -104,7 +104,7 @@ class StubBackend(CustomizerBackend):
         )
 
 
-@dataclass(slots=True)
+@dataclass
 class ScriptReferenceBackend(StubBackend):
     """Stub backend that also links an existing Python script artifact."""
 

--- a/tests/test_ui_assembly_pane.py
+++ b/tests/test_ui_assembly_pane.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
+pytest.importorskip("PySide6.QtCore", exc_type=ImportError)
+pytest.importorskip("PySide6.QtWidgets", exc_type=ImportError)
+
 from PySide6.QtCore import Qt
 
 from three_dfs.ui.assembly_pane import AssemblyComponent, AssemblyPane


### PR DESCRIPTION
## Summary
- wrap the CustomizerBackend runtime type in an abstract base class while preserving protocol typing for static analysis
- skip UI-oriented tests when PySide6 cannot be imported so headless environments avoid import failures
- relax customizer test backends to regular dataclasses so super() calls succeed without slots

## Testing
- python -m hatch -v run lint
- python -m hatch -v run test

------
https://chatgpt.com/codex/tasks/task_e_68d449a2b1c0832581e3e250129f7a49