### PR TITLE
Fix build123d text extrusion depth handling

### DIFF
--- a/src/three_dfs/customizer/transformations.py
+++ b/src/three_dfs/customizer/transformations.py
@@ -222,10 +222,8 @@ def _create_text_shape(
     if not faces:
         raise TransformationError("Text outline did not contain any faces")
 
-    extrusion_direction = Vector(0.0, 0.0, 1.0)
-    extrusions = [
-        face.extrude(amount=depth, direction=extrusion_direction) for face in faces
-    ]
+    extrusion_direction = Vector(0.0, 0.0, depth)
+    extrusions = [face.extrude(extrusion_direction) for face in faces]
     solid = extrusions[0] if len(extrusions) == 1 else Compound(extrusions)
     solid = _apply_matrix(solid, _translation_matrix((0.0, 0.0, -depth / 2.0)))
     if spacing != 1.0:


### PR DESCRIPTION
## Summary
- update the text emboss transformation to extrude faces using a vector whose magnitude encodes the desired depth
- rely on build123d's default behavior without unsupported keyword arguments to generate solids from text outlines

## Testing
- hatch run lint
- hatch run test

------
https://chatgpt.com/codex/tasks/task_e_68d564259e28832594d90940edabb166