### PR TITLE
Improve context menu state handling

### DIFF
--- a/src/three_dfs/application/main_window.py
+++ b/src/three_dfs/application/main_window.py
@@ -262,25 +262,31 @@ class MainWindow(QMainWindow):
         sidebar_menu.addAction(toggle_repo_action)
 
     def _show_repo_context_menu(self, pos) -> None:
+        current_item = self._repository_list.currentItem()
         try:
-            item = self._repository_list.itemAt(pos)
+            clicked_item = self._repository_list.itemAt(pos)
         except Exception:
-            item = None
-        if item is not None:
+            clicked_item = None
+        item = clicked_item or current_item
+        if clicked_item is not None and clicked_item is not current_item:
             try:
-                self._repository_list.setCurrentItem(item)
+                self._repository_list.setCurrentItem(clicked_item)
             except Exception:
                 pass
+            item = clicked_item
         from PySide6.QtWidgets import QMenu
 
         menu = QMenu(self)
         customize_act = None
-        if self._preview_pane.can_customize:
+        if item is not None and self._preview_pane.can_customize:
             customize_act = menu.addAction("Customize…")
             menu.addSeparator()
         new_project_act = menu.addAction("New Empty Project…")
         open_project_act = menu.addAction("Open as Project")
         open_folder_act = menu.addAction("Open Containing Folder")
+        has_selection = item is not None
+        open_project_act.setEnabled(has_selection)
+        open_folder_act.setEnabled(has_selection)
         global_pos = self._repository_list.mapToGlobal(pos)
         action = menu.exec(global_pos)
         if action is None:

--- a/src/three_dfs/ui/project_pane.py
+++ b/src/three_dfs/ui/project_pane.py
@@ -377,16 +377,22 @@ class ProjectPane(QWidget):
 
     @Slot()
     def _show_components_context_menu(self, pos) -> None:
+        current_item = self._components.currentItem()
         try:
-            item = self._components.itemAt(pos)
+            clicked_item = self._components.itemAt(pos)
         except Exception:
-            item = None
-        if item is not None:
-            self._components.setCurrentItem(item)
+            clicked_item = None
+        item = clicked_item or current_item
+        if clicked_item is not None and clicked_item is not current_item:
+            self._components.setCurrentItem(clicked_item)
+            item = clicked_item
         navigate_target = self._resolve_component_navigation_target(item)
         menu = QMenu(self)
+        has_project = bool(self._project_path)
         new_part_act = menu.addAction("New Part…")
+        new_part_act.setEnabled(has_project)
         add_act = menu.addAction("Add Attachment(s) Here…")
+        add_act.setEnabled(has_project)
         open_item_act = menu.addAction("Open Item")
         open_item_act.setEnabled(self._can_open_with_handler(item))
         open_project_act = menu.addAction("Open Project")
@@ -405,6 +411,9 @@ class ProjectPane(QWidget):
                 action.setData(related)
                 related_actions[action] = related
         open_act = menu.addAction("Open Containing Folder")
+        open_act.setEnabled(
+            has_project or self._absolute_path_for_item(item) is not None
+        )
         action = menu.exec(self._components.mapToGlobal(pos))
         if action is None:
             return


### PR DESCRIPTION
## Summary
- ensure the repository context menu falls back to the current selection and only enables project/folder actions when applicable
- update the project pane context menu to respect the active selection and disable project-scoped actions when no project is loaded

## Testing
- python -m hatch run lint
- python -m hatch run test


------
https://chatgpt.com/codex/tasks/task_e_68d5662a68e48325bf2fcd9a48196746