### PR TITLE
Fix lint warning in preview metadata formatting

### DIFF
--- a/src/three_dfs/ui/preview_pane.py
+++ b/src/three_dfs/ui/preview_pane.py
@@ -1110,7 +1110,7 @@ class PreviewPane(QWidget):
     def _stringify_metadata_value(self, value: Any) -> str:
         if value is None:
             return ""
-        if isinstance(value, (list, tuple, set)):
+        if isinstance(value, list | tuple | set):
             parts: list[str] = []
             for entry in value:
                 if isinstance(entry, Mapping):


### PR DESCRIPTION
## Summary
- replace the tuple of container types in the preview pane metadata stringifier with the modern union syntax required by Ruff

## Testing
- ruff check src tests
- black --check src tests
- pytest --cov=three_dfs --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d5875ffc9883258c6bd9647b738caa