### PR TITLE
Add Thingiverse import plugin

### DIFF
--- a/src/three_dfs/import_plugins/__init__.py
+++ b/src/three_dfs/import_plugins/__init__.py
@@ -217,3 +217,9 @@ def scaffold_plugin(repo_name: str, target_dir: Path | str) -> Path:
     destination.write_text(template, encoding="utf-8")
     logger.info("Plugin scaffold written to %s", destination)
     return destination
+
+
+try:  # pragma: no cover - import side effects exercised elsewhere
+    from . import thingiverse_plugin as _thingiverse_plugin  # noqa: F401
+except Exception:  # pragma: no cover - defensive logging
+    logger.exception("Failed to import built-in Thingiverse plugin")

--- a/src/three_dfs/import_plugins/thingiverse_plugin.py
+++ b/src/three_dfs/import_plugins/thingiverse_plugin.py
@@ -1,0 +1,251 @@
+"""Importer plugin that fetches assets from Thingiverse."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from . import ImportPlugin, register_plugin
+
+
+class ThingiverseImportPlugin(ImportPlugin):
+    """Fetch projects hosted on Thingiverse via the public API."""
+
+    API_ROOT = "https://api.thingiverse.com"
+    WEB_ROOT = "https://www.thingiverse.com"
+    USER_AGENT = "three-dfs-thingiverse-plugin/1.0"
+    TOKEN_ENV_VAR = "THINGIVERSE_TOKEN"
+
+    _THING_PATTERN = re.compile(r"thing:(?P<id>\d+)", re.IGNORECASE)
+    _THING_PATH_PATTERN = re.compile(r"/things?/(?P<id>\d+)")
+
+    _SUPPORTED_SUFFIXES = {
+        ".fbx",
+        ".gltf",
+        ".glb",
+        ".obj",
+        ".ply",
+        ".step",
+        ".stl",
+        ".stp",
+    }
+
+    def __init__(
+        self,
+        *,
+        token: str | None = None,
+        opener: Callable[[urllib.request.Request], Any] | None = None,
+    ) -> None:
+        self._token = token
+        self._opener = opener or urllib.request.urlopen
+
+    def can_handle(self, source: str) -> bool:
+        return self._extract_thing_id(source) is not None
+
+    def fetch(self, source: str, destination: Path) -> dict[str, Any]:
+        thing_id = self._extract_thing_id(source)
+        if thing_id is None:
+            message = "Thingiverse plugin requires a valid thing identifier."
+            raise RuntimeError(message)
+
+        token = self._token or os.environ.get(self.TOKEN_ENV_VAR)
+        if not token:
+            message = (
+                "Thingiverse API token missing. Set the THINGIVERSE_TOKEN "
+                "environment variable or provide a token to the plugin."
+            )
+            raise RuntimeError(message)
+
+        thing_endpoint = f"{self.API_ROOT}/things/{thing_id}"
+        files_endpoint = f"{thing_endpoint}/files"
+
+        thing_payload = self._get_json(thing_endpoint, token)
+        files_payload = self._get_json(files_endpoint, token)
+
+        primary_file = self._select_primary_file(files_payload)
+        if primary_file is None:
+            message = (
+                "Thingiverse listing does not expose files with supported "
+                "extensions."
+            )
+            raise RuntimeError(message)
+
+        download_url = self._file_download_url(primary_file)
+        if not download_url:
+            message = "Unable to locate a download URL for the selected file."
+            raise RuntimeError(message)
+
+        self._download_file(download_url, destination, token)
+
+        filename = str(primary_file.get("name") or f"thing_{thing_id}.stl")
+        extension = Path(filename).suffix
+        if not extension:
+            extension = self._infer_extension_from_url(download_url)
+            if extension:
+                filename = f"{filename}{extension}"
+        extension = extension.lower()
+
+        files_metadata = self._build_files_metadata(files_payload, primary_file)
+
+        metadata: dict[str, Any] = {
+            "label": thing_payload.get("name") or f"Thingiverse {thing_id}",
+            "filename": filename,
+            "extension": extension or ".stl",
+            "thingiverse": {
+                "id": int(thing_id),
+                "name": thing_payload.get("name"),
+                "url": f"{self.WEB_ROOT}/thing:{thing_id}",
+                "creator": self._extract_creator(thing_payload.get("creator")),
+                "license": (
+                    thing_payload.get("license") or thing_payload.get("license_name")
+                ),
+                "tags": self._extract_tags(thing_payload.get("tags", [])),
+                "summary": thing_payload.get("description"),
+                "thumbnail": thing_payload.get("thumbnail"),
+                "files": files_metadata,
+            },
+            "source_links": {
+                "thingiverse": f"{self.WEB_ROOT}/thing:{thing_id}",
+            },
+        }
+
+        return metadata
+
+    def _extract_thing_id(self, source: str) -> str | None:
+        if not source:
+            return None
+
+        match = self._THING_PATTERN.fullmatch(source)
+        if match:
+            return match.group("id")
+
+        try:
+            parsed = urllib.parse.urlparse(source)
+        except Exception:
+            parsed = None
+
+        if parsed and parsed.netloc and "thingiverse" in parsed.netloc.lower():
+            path_match = self._THING_PATTERN.search(parsed.path or "")
+            if path_match:
+                return path_match.group("id")
+            alternate_match = self._THING_PATH_PATTERN.search(parsed.path)
+            if alternate_match:
+                return alternate_match.group("id")
+
+        if source.isdigit():
+            return source
+
+        return None
+
+    def _get_json(self, url: str, token: str) -> Any:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+                "User-Agent": self.USER_AGENT,
+            },
+        )
+        with self._opener(request) as response:
+            payload = response.read()
+
+        try:
+            return json.loads(payload.decode("utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise RuntimeError(f"Invalid JSON response from {url!s}") from exc
+
+    def _download_file(self, url: str, destination: Path, token: str) -> None:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "User-Agent": self.USER_AGENT,
+            },
+        )
+        with self._opener(request) as response, destination.open("wb") as target:
+            shutil.copyfileobj(response, target)
+
+    def _select_primary_file(
+        self, files: Iterable[Mapping[str, Any]]
+    ) -> Mapping[str, Any] | None:
+        supported: list[Mapping[str, Any]] = []
+        for file_info in files:
+            name = str(file_info.get("name") or "")
+            if Path(name).suffix.lower() in self._SUPPORTED_SUFFIXES:
+                supported.append(file_info)
+
+        if not supported:
+            return None
+
+        def sort_key(item: Mapping[str, Any]) -> tuple[int, int]:
+            primary_flag = int(bool(item.get("is_primary") or item.get("default")))
+            identifier = int(item.get("id") or 0)
+            return (-primary_flag, identifier)
+
+        supported.sort(key=sort_key)
+        return supported[0]
+
+    def _file_download_url(self, file_info: Mapping[str, Any]) -> str:
+        return str(
+            file_info.get("download_url")
+            or file_info.get("direct_url")
+            or file_info.get("url")
+            or ""
+        )
+
+    def _infer_extension_from_url(self, url: str) -> str:
+        suffix = Path(urllib.parse.urlparse(url).path).suffix
+        return suffix.lower()
+
+    def _build_files_metadata(
+        self,
+        files: Iterable[Mapping[str, Any]],
+        primary: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
+        primary_id = primary.get("id")
+        result: list[dict[str, Any]] = []
+        for file_info in files:
+            entry = {
+                "id": file_info.get("id"),
+                "name": file_info.get("name"),
+                "size": file_info.get("size"),
+                "public_url": file_info.get("public_url"),
+                "download_url": file_info.get("download_url"),
+                "primary": file_info.get("id") == primary_id,
+            }
+            extension = Path(str(file_info.get("name") or "")).suffix.lower()
+            if extension:
+                entry["extension"] = extension
+            result.append(entry)
+        return result
+
+    def _extract_creator(
+        self, creator_payload: Mapping[str, Any] | None
+    ) -> dict[str, Any] | None:
+        if not creator_payload:
+            return None
+
+        return {
+            "id": creator_payload.get("id"),
+            "name": creator_payload.get("name"),
+            "url": creator_payload.get("url"),
+            "public_url": creator_payload.get("public_url"),
+        }
+
+    def _extract_tags(self, tags_payload: Iterable[Mapping[str, Any]]) -> list[str]:
+        tags: list[str] = []
+        for entry in tags_payload:
+            name = entry.get("name")
+            if isinstance(name, str):
+                tags.append(name)
+        return tags
+
+
+register_plugin(ThingiverseImportPlugin())

--- a/tests/import_plugins/test_thingiverse_plugin.py
+++ b/tests/import_plugins/test_thingiverse_plugin.py
@@ -1,0 +1,170 @@
+"""Tests covering the Thingiverse import plugin."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from three_dfs.import_plugins.thingiverse_plugin import ThingiverseImportPlugin
+
+
+class FakeResponse:
+    """File-like response object used to emulate urllib downloads."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self._position = 0
+
+    def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            size = len(self._payload) - self._position
+        start = self._position
+        end = min(start + size, len(self._payload))
+        self._position = end
+        return self._payload[start:end]
+
+    def close(self) -> None:  # pragma: no cover - compatibility stub
+        self._payload = b""
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class FakeOpener:
+    """Callable mimicking :func:`urllib.request.urlopen` for tests."""
+
+    def __init__(self, responses: dict[str, bytes]) -> None:
+        self._responses = responses
+        self.requests: list[Any] = []
+
+    def __call__(self, request: Any) -> FakeResponse:
+        url = getattr(request, "full_url", request)
+        self.requests.append(request)
+        try:
+            payload = self._responses[url]
+        except KeyError as err:  # pragma: no cover - defensive guard
+            raise AssertionError(f"Unexpected URL requested: {url}") from err
+        return FakeResponse(payload)
+
+
+@pytest.mark.parametrize(
+    ("identifier", "expected"),
+    [
+        ("https://www.thingiverse.com/thing:12345", True),
+        ("https://www.thingiverse.com/things/67890", True),
+        ("thing:555", True),
+        ("555", True),
+        ("https://example.com/thing:555", False),
+        ("", False),
+    ],
+)
+def test_can_handle_variants(identifier: str, expected: bool) -> None:
+    """Plugin should recognise multiple Thingiverse identifier formats."""
+
+    plugin = ThingiverseImportPlugin(token="dummy", opener=FakeOpener({}))
+    assert plugin.can_handle(identifier) is expected
+
+
+def test_fetch_downloads_primary_file(tmp_path: Path) -> None:
+    """Fetching a Thingiverse listing should download the preferred asset."""
+
+    thing_payload = {
+        "id": 4242,
+        "name": "Calibration Cube",
+        "description": "Simple cube used for calibration.",
+        "thumbnail": "https://cdn.thingiverse.com/thing.jpg",
+        "creator": {
+            "id": 101,
+            "name": "makerbot",
+            "public_url": "https://www.thingiverse.com/makerbot",
+            "url": "https://api.thingiverse.com/users/makerbot",
+        },
+        "tags": [{"name": "calibration"}, {"name": "cube"}],
+    }
+    files_payload = [
+        {
+            "id": 1,
+            "name": "calibration_cube.stl",
+            "size": 1234,
+            "public_url": "https://www.thingiverse.com/thing:4242/files",
+            "download_url": "https://cdn.thingiverse.com/download/calibration_cube.stl",
+            "is_primary": True,
+        },
+        {
+            "id": 2,
+            "name": "notes.txt",
+            "size": 56,
+            "public_url": "https://www.thingiverse.com/thing:4242/files",
+            "download_url": "https://cdn.thingiverse.com/download/notes.txt",
+        },
+    ]
+    downloaded_asset = b"solid cube\nendsolid cube\n"
+
+    api_root = ThingiverseImportPlugin.API_ROOT
+    responses = {
+        f"{api_root}/things/4242": json.dumps(thing_payload).encode("utf-8"),
+        f"{api_root}/things/4242/files": json.dumps(files_payload).encode("utf-8"),
+        "https://cdn.thingiverse.com/download/calibration_cube.stl": downloaded_asset,
+    }
+    opener = FakeOpener(responses)
+    plugin = ThingiverseImportPlugin(token="secret-token", opener=opener)
+
+    destination = tmp_path / "download.tmp"
+    metadata = plugin.fetch("https://www.thingiverse.com/thing:4242", destination)
+
+    assert destination.read_bytes() == downloaded_asset
+    assert metadata["filename"] == "calibration_cube.stl"
+    assert metadata["extension"] == ".stl"
+    assert metadata["label"] == "Calibration Cube"
+
+    thing_metadata = metadata["thingiverse"]
+    assert thing_metadata["id"] == 4242
+    assert thing_metadata["creator"]["name"] == "makerbot"
+    assert thing_metadata["files"][0]["primary"] is True
+    assert thing_metadata["files"][0]["download_url"].endswith("calibration_cube.stl")
+
+    # All HTTP calls should carry the Thingiverse API token.
+    auth_headers = [request.headers.get("Authorization") for request in opener.requests]
+    assert auth_headers[:2] == ["Bearer secret-token", "Bearer secret-token"]
+    assert auth_headers[-1] == "Bearer secret-token"
+
+
+def test_fetch_requires_api_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The plugin should emit a clear error when authentication is missing."""
+
+    monkeypatch.delenv("THINGIVERSE_TOKEN", raising=False)
+    plugin = ThingiverseImportPlugin(opener=FakeOpener({}))
+
+    with pytest.raises(RuntimeError, match="Thingiverse API token"):
+        plugin.fetch("thing:999", tmp_path / "asset.tmp")
+
+
+def test_fetch_errors_when_no_supported_files(tmp_path: Path) -> None:
+    """Listings without supported file types should raise an error."""
+
+    thing_payload = {"id": 123, "name": "Unsupported"}
+    files_payload = [
+        {
+            "id": 11,
+            "name": "notes.txt",
+            "download_url": "https://cdn.thingiverse.com/download/notes.txt",
+        }
+    ]
+
+    api_root = ThingiverseImportPlugin.API_ROOT
+    responses = {
+        f"{api_root}/things/123": json.dumps(thing_payload).encode("utf-8"),
+        f"{api_root}/things/123/files": json.dumps(files_payload).encode("utf-8"),
+    }
+    plugin = ThingiverseImportPlugin(token="token", opener=FakeOpener(responses))
+
+    with pytest.raises(RuntimeError, match="supported extensions"):
+        plugin.fetch("thing:123", tmp_path / "asset.tmp")


### PR DESCRIPTION
## Summary
- add a Thingiverse import plugin that authenticates with the Thingiverse API, downloads the selected asset, and records source metadata
- load the built-in plugin during import plugin discovery and add targeted unit tests for its behaviours

## Testing
- .venv/bin/hatch run lint
- .venv/bin/hatch run test

------
https://chatgpt.com/codex/tasks/task_e_68d59695c44c8325ab62a2730be557de