### PR TITLE
Add settings dialog and persist UI preferences

### DIFF
--- a/src/three_dfs/application/settings.py
+++ b/src/three_dfs/application/settings.py
@@ -1,0 +1,113 @@
+"""Persistence helpers for user-configurable application settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from PySide6.QtCore import QSettings
+
+from ..utils.paths import coerce_optional_path
+
+__all__ = [
+    "APPLICATION_NAME",
+    "AppSettings",
+    "ORGANIZATION_NAME",
+    "load_app_settings",
+    "save_app_settings",
+]
+
+
+ORGANIZATION_NAME: Final[str] = "Open3DFS"
+"""Organization identifier used when storing Qt settings."""
+
+APPLICATION_NAME: Final[str] = "3dfs"
+"""Application identifier used when storing Qt settings."""
+
+
+@dataclass(slots=True)
+class AppSettings:
+    """Collection of end-user preferences for the desktop shell."""
+
+    library_root: Path
+    show_repository_sidebar: bool = False
+    auto_refresh_projects: bool = True
+    bootstrap_demo_data: bool = False
+    text_preview_limit: int = 200_000
+
+
+def _coerce_bool(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _settings_storage() -> QSettings:
+    return QSettings(ORGANIZATION_NAME, APPLICATION_NAME)
+
+
+def load_app_settings(*, fallback_root: Path) -> AppSettings:
+    """Return persisted settings falling back to *fallback_root* when needed."""
+
+    store = _settings_storage()
+
+    raw_library = store.value("general/libraryRoot")
+    library_root = coerce_optional_path(raw_library) or fallback_root
+
+    show_repo = _coerce_bool(
+        store.value("interface/showRepositorySidebar"), False
+    )
+    auto_refresh = _coerce_bool(store.value("projects/autoRefresh"), True)
+    bootstrap_demo = _coerce_bool(store.value("general/bootstrapDemoData"), False)
+
+    text_limit_value = store.value("preview/textLimit")
+    if isinstance(text_limit_value, int):
+        text_limit = max(10_240, text_limit_value)
+    elif isinstance(text_limit_value, str):
+        stripped = text_limit_value.strip()
+        text_limit = int(stripped) if stripped.isdigit() else 200_000
+        text_limit = max(10_240, text_limit)
+    else:
+        text_limit = 200_000
+
+    return AppSettings(
+        library_root=library_root,
+        show_repository_sidebar=show_repo,
+        auto_refresh_projects=auto_refresh,
+        bootstrap_demo_data=bootstrap_demo,
+        text_preview_limit=text_limit,
+    )
+
+
+def save_app_settings(settings: AppSettings) -> None:
+    """Persist *settings* using Qt's :class:`~PySide6.QtCore.QSettings`."""
+
+    store = _settings_storage()
+
+    store.beginGroup("general")
+    store.setValue("libraryRoot", str(settings.library_root))
+    store.setValue("bootstrapDemoData", settings.bootstrap_demo_data)
+    store.endGroup()
+
+    store.beginGroup("interface")
+    store.setValue("showRepositorySidebar", settings.show_repository_sidebar)
+    store.endGroup()
+
+    store.beginGroup("projects")
+    store.setValue("autoRefresh", settings.auto_refresh_projects)
+    store.endGroup()
+
+    store.beginGroup("preview")
+    store.setValue("textLimit", int(settings.text_preview_limit))
+    store.endGroup()
+
+    store.sync()

--- a/src/three_dfs/ui/__init__.py
+++ b/src/three_dfs/ui/__init__.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from .customizer_dialog import CustomizerDialog
 from .preview_pane import PreviewPane
 from .project_pane import ProjectPane
+from .settings_dialog import SettingsDialog
 from .tag_sidebar import TagSidebar
 
-__all__ = ["ProjectPane", "CustomizerDialog", "PreviewPane", "TagSidebar"]
+__all__ = [
+    "ProjectPane",
+    "CustomizerDialog",
+    "PreviewPane",
+    "SettingsDialog",
+    "TagSidebar",
+]

--- a/src/three_dfs/ui/settings_dialog.py
+++ b/src/three_dfs/ui/settings_dialog.py
@@ -1,0 +1,218 @@
+"""Modal dialog that exposes configurable application preferences."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..application.settings import AppSettings
+from ..utils.paths import coerce_required_path
+
+__all__ = ["SettingsDialog"]
+
+
+class SettingsDialog(QDialog):
+    """Collect and persist user-facing preferences."""
+
+    def __init__(self, settings: AppSettings, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Settings")
+        self.setModal(True)
+
+        self._initial = settings
+        self._result: AppSettings | None = None
+
+        self._tabs = QTabWidget(self)
+
+        self._library_input = QLineEdit(str(settings.library_root))
+        self._library_input.setPlaceholderText(
+            "Choose the root folder for your library"
+        )
+
+        general_tab = self._build_general_tab(settings)
+        interface_tab = self._build_interface_tab(settings)
+        projects_tab = self._build_projects_tab(settings)
+
+        self._tabs.addTab(general_tab, "General")
+        self._tabs.addTab(interface_tab, "Interface")
+        self._tabs.addTab(projects_tab, "Projects")
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok
+            | QDialogButtonBox.StandardButton.Cancel,
+            Qt.Horizontal,
+            self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self._tabs)
+        layout.addWidget(buttons)
+
+        self.resize(520, 360)
+
+    # ------------------------------------------------------------------
+    # Tab builders
+    # ------------------------------------------------------------------
+    def _build_general_tab(self, settings: AppSettings) -> QWidget:
+        container = QWidget(self)
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
+
+        library_box = QGroupBox("Library")
+        library_layout = QFormLayout(library_box)
+        library_layout.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+
+        library_path_row = QWidget(library_box)
+        library_path_layout = QHBoxLayout(library_path_row)
+        library_path_layout.setContentsMargins(0, 0, 0, 0)
+        library_path_layout.setSpacing(6)
+        library_path_layout.addWidget(self._library_input, 1)
+        browse_btn = QPushButton("Browse…", library_path_row)
+        browse_btn.clicked.connect(self._choose_library_root)
+        library_path_layout.addWidget(browse_btn)
+        library_layout.addRow("Library root", library_path_row)
+
+        self._demo_checkbox = QCheckBox(
+            "Seed example entries when the library is empty", library_box
+        )
+        self._demo_checkbox.setChecked(settings.bootstrap_demo_data)
+        info_label = QLabel(
+            "When enabled the application adds a curated set of sample assets "
+            "to help explore features."
+        )
+        info_label.setWordWrap(True)
+        info_label.setObjectName("demoInfoLabel")
+        library_layout.addRow(self._demo_checkbox)
+        library_layout.addRow(info_label)
+
+        layout.addWidget(library_box)
+        layout.addStretch(1)
+        return container
+
+    def _build_interface_tab(self, settings: AppSettings) -> QWidget:
+        container = QWidget(self)
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
+
+        interface_box = QGroupBox("Layout")
+        interface_layout = QVBoxLayout(interface_box)
+
+        self._sidebar_checkbox = QCheckBox(
+            "Show repository sidebar on startup", interface_box
+        )
+        self._sidebar_checkbox.setChecked(settings.show_repository_sidebar)
+        interface_layout.addWidget(self._sidebar_checkbox)
+
+        description = QLabel(
+            "The repository sidebar provides quick access to discovered assets. "
+            "You can also toggle it from the View menu."
+        )
+        description.setWordWrap(True)
+        interface_layout.addWidget(description)
+
+        layout.addWidget(interface_box)
+        layout.addStretch(1)
+        return container
+
+    def _build_projects_tab(self, settings: AppSettings) -> QWidget:
+        container = QWidget(self)
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
+
+        projects_box = QGroupBox("Automation")
+        projects_layout = QVBoxLayout(projects_box)
+
+        self._auto_refresh_checkbox = QCheckBox(
+            "Automatically refresh open projects when files change",
+            projects_box,
+        )
+        self._auto_refresh_checkbox.setChecked(settings.auto_refresh_projects)
+        projects_layout.addWidget(self._auto_refresh_checkbox)
+
+        preview_box = QGroupBox("Preview")
+        preview_layout = QFormLayout(preview_box)
+        preview_layout.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+
+        self._preview_limit_spin = QSpinBox(preview_box)
+        self._preview_limit_spin.setRange(10, 4096)
+        self._preview_limit_spin.setSuffix(" KB")
+        self._preview_limit_spin.setValue(
+            max(10, settings.text_preview_limit // 1024)
+        )
+        self._preview_limit_spin.setToolTip(
+            "Maximum amount of text loaded when displaying README or source files."
+        )
+        preview_layout.addRow("Text preview limit", self._preview_limit_spin)
+
+        layout.addWidget(projects_box)
+        layout.addWidget(preview_box)
+        layout.addStretch(1)
+        return container
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _choose_library_root(self) -> None:
+        current = Path(self._library_input.text() or str(self._initial.library_root))
+        start_dir = (
+            str(current) if current.exists() else str(self._initial.library_root)
+        )
+        chosen = QFileDialog.getExistingDirectory(
+            self,
+            "Select library root",
+            start_dir,
+        )
+        if chosen:
+            self._library_input.setText(chosen)
+
+    def accept(self) -> None:  # type: ignore[override]
+        try:
+            library_root = coerce_required_path(self._library_input.text())
+        except (TypeError, ValueError) as exc:
+            QMessageBox.warning(
+                self,
+                "Invalid library path",
+                str(exc),
+            )
+            return
+
+        updated = replace(
+            self._initial,
+            library_root=library_root,
+            show_repository_sidebar=self._sidebar_checkbox.isChecked(),
+            auto_refresh_projects=self._auto_refresh_checkbox.isChecked(),
+            bootstrap_demo_data=self._demo_checkbox.isChecked(),
+            text_preview_limit=max(10_240, self._preview_limit_spin.value() * 1024),
+        )
+
+        self._result = updated
+        super().accept()
+
+    def result_settings(self) -> AppSettings | None:
+        """Return the settings captured when the dialog was accepted."""
+
+        return self._result


### PR DESCRIPTION
## Summary
- add an application-level settings module backed by QSettings and load/save helpers
- introduce a multi-tab settings dialog with options for library path, sidebar visibility, project refresh, and text preview size
- wire the main window and preview pane to respect persisted preferences and refresh watchers accordingly

## Testing
- ruff check src tests
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d5a80504f0832599796e7f7fa57678