### PR TITLE
Handle recursive metadata payloads

### DIFF
--- a/src/three_dfs/storage/repository.py
+++ b/src/three_dfs/storage/repository.py
@@ -862,7 +862,7 @@ class AssetRepository:
             return {}
         try:
             data = json.loads(payload)
-        except json.JSONDecodeError:
+        except (RecursionError, json.JSONDecodeError):
             return {}
         if isinstance(data, dict):
             return dict(data)


### PR DESCRIPTION
## Summary
- guard metadata deserialization against recursion errors and fall back to empty metadata
- add regression test ensuring assets with deeply nested metadata no longer crash when fetched

## Testing
- pytest tests/storage/test_repository.py

------
https://chatgpt.com/codex/tasks/task_e_68d74931eb38832596344c4fe4bd381e