### PR TITLE
Prevent recursive sqlite3 imports when opening storage connections

### DIFF
--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -1,0 +1,30 @@
+"""Tests for the low-level SQLite helpers."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from three_dfs.storage import database
+
+
+class DummyError(RuntimeError):
+    """Raised when the monkeypatched connect function is called."""
+
+
+def test_connect_uses_original_sqlite3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``SQLiteStorage.connect`` should ignore later sqlite3 monkeypatches."""
+
+    storage = database.SQLiteStorage(":memory:")
+
+    def exploding_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        raise DummyError("patched sqlite3.connect should not be called")
+
+    monkeypatch.setattr(database.sqlite3, "connect", exploding_connect)
+
+    connection = storage.connect()
+    try:
+        assert isinstance(connection, sqlite3.Connection)
+    finally:
+        connection.close()


### PR DESCRIPTION
## Summary
- capture the original sqlite3 connect and row_factory callables to avoid recursive re-imports
- add a regression test that ensures SQLiteStorage.connect ignores later sqlite3 monkeypatches

## Testing
- pytest tests/storage -q

------
https://chatgpt.com/codex/tasks/task_e_68d81d4722ac832599c6f6536b187ae1